### PR TITLE
collada_urdf_jsk_patch/Makefile: use catkin build to compile robot_model

### DIFF
--- a/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
+++ b/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
@@ -13,12 +13,12 @@ disable_ssl:
 	git config --global http.sslVerify false
 
 urdf_to_collada: disable_ssl $(GIT_DIR) patched
-	(cd build/robot_model; PKG_CONFIG_PATH=`rospack find assimp_devel`/lib/pkgconfig:${PKG_CONFIG_PATH} catkin_make --pkg collada_urdf --force-cmake)
+	(cd build/robot_model; catkin init -w .; PKG_CONFIG_PATH=`rospack find assimp_devel`/lib/pkgconfig:${PKG_CONFIG_PATH} catkin build collada_urdf --force-cmake --no-status)
 	cp $(BUILD_BIN_DIR)/urdf_to_collada .
 	cp $(BUILD_BIN_DIR)/collada_to_urdf .
 
 clean:
-	if [ -f build/robot_model/build ] ; then catkin_make clean; fi
+	if [ -f build/robot_model/build ] ; then catkin clean -a; fi
 	rm -fr build/robot_model/build
 	rm -rf installed patched
 	rm -f urdf_to_collada


### PR DESCRIPTION
fix for https://github.com/jsk-ros-pkg/jsk_common/pull/1069