### PR TITLE
add ca-certificates for https download

### DIFF
--- a/3rdparty/assimp_devel/package.xml
+++ b/3rdparty/assimp_devel/package.xml
@@ -12,6 +12,8 @@
   <build_depend>boost</build_depend>
   <build_depend>zlib</build_depend>
   <build_depend>unzip</build_depend>
+  <build_depend>ca-certificates</build_depend>
+  <build_depend>openssl</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>zlib</run_depend>

--- a/3rdparty/ff/package.xml
+++ b/3rdparty/ff/package.xml
@@ -23,6 +23,8 @@
   <build_depend>rosbash</build_depend>
   <build_depend>rospack</build_depend>
   <build_depend>roslib</build_depend>
+  <build_depend>ca-certificates</build_depend>
+  <build_depend>openssl</build_depend>
  
   <export>
 


### PR DESCRIPTION
http://jenkins.ros.org/job/ros-jade-ff_binarydeb_vivid_i386/52/

```
[ 50%] Generating installed
make -f /tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/Makefile MD5SUM_DIR=/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647
make[5]: Entering directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/obj-i686-linux-gnu'
mkdir -p build
if [ ! -f /tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/FF-v2.3.tgz.md5sum ]; then echo "Error: Couldn't find md5sum file /tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/FF-v2.3.tgz.md5sum" && false; fi
/opt/ros/jade/share/ros/core/rosbuild/bin/download_checkmd5.py http://github.com/jsk-ros-pkg/archives/raw/master/FF-v2.3.tgz build/FF-v2.3.tgz `awk {'print $1'} /tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/FF-v2.3.tgz.md5sum`
[rosbuild] Downloading http://github.com/jsk-ros-pkg/archives/raw/master/FF-v2.3.tgz to build/FF-v2.3.tgz...Traceback (most recent call last):
  File "/opt/ros/jade/share/ros/core/rosbuild/bin/download_checkmd5.py", line 89, in <module>
    sys.exit(main())
  File "/opt/ros/jade/share/ros/core/rosbuild/bin/download_checkmd5.py", line 61, in main
    urllib.urlretrieve(uri, dest)
  File "/usr/lib/python2.7/urllib.py", line 98, in urlretrieve
    return opener.retrieve(url, filename, reporthook, data)
  File "/usr/lib/python2.7/urllib.py", line 245, in retrieve
    fp = self.open(url, data)
  File "/usr/lib/python2.7/urllib.py", line 213, in open
    return getattr(self, name)(url)
  File "/usr/lib/python2.7/urllib.py", line 364, in open_http
    return self.http_error(url, fp, errcode, errmsg, headers)
  File "/usr/lib/python2.7/urllib.py", line 377, in http_error
    result = method(url, fp, errcode, errmsg, headers)
  File "/usr/lib/python2.7/urllib.py", line 671, in http_error_301
    return self.http_error_302(url, fp, errcode, errmsg, headers, data)
  File "/usr/lib/python2.7/urllib.py", line 641, in http_error_302
    data)
  File "/usr/lib/python2.7/urllib.py", line 667, in redirect_internal
    return self.open(newurl)
  File "/usr/lib/python2.7/urllib.py", line 213, in open
    return getattr(self, name)(url)
  File "/usr/lib/python2.7/urllib.py", line 443, in open_https
    h.endheaders(data)
  File "/usr/lib/python2.7/httplib.py", line 1044, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 888, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 850, in send
    self.connect()
  File "/usr/lib/python2.7/httplib.py", line 1269, in connect
    server_hostname=server_hostname)
  File "/usr/lib/python2.7/ssl.py", line 352, in wrap_socket
    _context=self)
  File "/usr/lib/python2.7/ssl.py", line 579, in __init__
    self.do_handshake()
  File "/usr/lib/python2.7/ssl.py", line 808, in do_handshake
    self._sslobj.do_handshake()
IOError: [Errno socket error] [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
/opt/ros/jade/share/mk/download_unpack_build.mk:37: recipe for target 'build/FF-v2.3/unpacked' failed
make[5]: *** [build/FF-v2.3/unpacked] Error 1
make[5]: Leaving directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/obj-i686-linux-gnu'
CMakeFiles/ff_install.dir/build.make:59: recipe for target 'installed' failed
make[4]: *** [installed] Error 2
make[4]: Leaving directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/obj-i686-linux-gnu'
CMakeFiles/Makefile2:187: recipe for target 'CMakeFiles/ff_install.dir/all' failed
make[3]: *** [CMakeFiles/ff_install.dir/all] Error 2
make[3]: Leaving directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/obj-i686-linux-gnu'
Makefile:120: recipe for target 'all' failed
make[2]: *** [all] Error 2
make[2]: Leaving directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647/obj-i686-linux-gnu'
dh_auto_build: make -j1 returned exit code 2
debian/rules:36: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 2
make[1]: Leaving directory '/tmp/buildd/ros-jade-ff-2.0.3-0vivid-20150816-0647'
debian/rules:23: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
E: Failed autobuilding of package
```