### PR TITLE
[libcmt] Fix libcmt_LIBRARIES variable

### DIFF
--- a/3rdparty/libcmt/CMakeLists.txt
+++ b/3rdparty/libcmt/CMakeLists.txt
@@ -20,4 +20,5 @@ ExternalProject_Add(
   )
 
 catkin_package(
+  LIBRARIES cmt
   )


### PR DESCRIPTION
depends on https://github.com/aginika/libCMT/pull/1
