### PR TITLE
Enable text2wave using VoiceText other than pr2 robots.

### DIFF
--- a/3rdparty/voice_text/text2wave
+++ b/3rdparty/voice_text/text2wave
@@ -20,8 +20,28 @@ do
 	esac
 done
 
+# Specify options
+# Because text2wave is called from soundplay_node.py and it is difficult to add arguments, we use environments.
+if [ -v VOICETEXT_TEXT2WAV_USE_LOCAL_MODE ]; # Use voice_text on local machine or remote machine.
+then
+    USE_LOCAL_MODE=1
+else
+    USE_LOCAL_MODE=0
+fi
+if [ -v VOICETEXT_TEXT2WAV_REMOTE_HOST ]; # Specify remote machine hostname, c2 by default.
+then
+    REMOTE_HOST=$VOICETEXT_TEXT2WAV_REMOTE_HOST
+else
+    REMOTE_HOST=c2
+fi
+
 nkf -s $INPUT_FILE > $JPTEXT_FILE
-scp $JPTEXT_FILE c2:$JPTEXT_FILE
-ssh c2 $COMMAND -o $OUTPUT_FILE $JPTEXT_FILE
-scp c2:$OUTPUT_FILE $OUTPUT_FILE
+if [ $USE_LOCAL_MODE -eq 0 ];
+then
+    scp $JPTEXT_FILE $REMOTE_HOST:$JPTEXT_FILE
+    ssh $REMOTE_HOST $COMMAND -o $OUTPUT_FILE $JPTEXT_FILE
+    scp $REMOTE_HOST:$OUTPUT_FILE $OUTPUT_FILE
+else
+    $COMMAND -o $OUTPUT_FILE $JPTEXT_FILE
+fi;
 #rm -f /tmp/_voice_text_*_$$.*


### PR DESCRIPTION
Enable text2wave using VoiceText other than pr2 robots.
Previously, `c2` machine name is hard-coded.

Using this PR, text2wave can used for
- local machine voicetext
- hostname other than c2

Default behavior may be not changed (remote machine mode and hostname is `c2`).

To specify these options, I used environments instead of arguments for text2wave 
because it is difficult to add argument from soundplay_node.py:
http://docs.ros.org/jade/api/sound_play/html/soundplay__node_8py_source.html

How to use
```
<launch>
  <node pkg="sound_play" type="soundplay_node.py" name="robotsound_jp" output="screen">
    <env name="PATH" value="$(find voice_text):$(env PATH)" />
    <env name="VOICETEXT_TEXT2WAV_USE_LOCAL_MODE" value="tru" />
    <remap from="robotsound" to="robotsound_jp" />
  </node>
</launch>
```

@furushchev , could you check this PR on PR2?
New text2wave should work on PR2.