### PR TITLE
[libsiftfast] Use PYTHON_INSTALL_DIR to install python module with catkin

### DIFF
--- a/3rdparty/libsiftfast/CMakeLists.txt
+++ b/3rdparty/libsiftfast/CMakeLists.txt
@@ -7,7 +7,7 @@ add_custom_target(libsiftfast ALL
   DEPENDS ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.so)
 add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.so
   DEPENDS Makefile
-  COMMAND  make -f ${PROJECT_SOURCE_DIR}/Makefile SOURCE_DIR=${PROJECT_SOURCE_DIR} INSTALL_DIR=${CATKIN_DEVEL_PREFIX})
+  COMMAND  make -f ${PROJECT_SOURCE_DIR}/Makefile SOURCE_DIR=${PROJECT_SOURCE_DIR} INSTALL_DIR=${CATKIN_DEVEL_PREFIX} PYTHON_INSTALL_DIR=${PYTHON_INSTALL_DIR})
 
 # force install directory for catkin_package
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
@@ -30,11 +30,8 @@ endif()
 install(PROGRAMS ${CATKIN_DEVEL_PREFIX}/bin/siftfast
         DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
-execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from catkin_tools.verbs.catkin_build.common import get_python_install_dir; sys.stdout.write(get_python_install_dir())"
-  OUTPUT_VARIABLE _python_install_dir)
 install(CODE "
-  FILE(INSTALL DESTINATION ${CMAKE_INSTALL_PREFIX}/${_python_install_dir} TYPE PROGRAM FILES ${CATKIN_DEVEL_PREFIX}/${_python_install_dir}/siftfastpy.so)
+  FILE(INSTALL DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR} TYPE PROGRAM FILES ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/siftfastpy.so)
 ")
 
 install(CODE "

--- a/3rdparty/libsiftfast/Makefile
+++ b/3rdparty/libsiftfast/Makefile
@@ -12,7 +12,7 @@ build: SVN_UP libsiftfast
 
 BOOST_INCLUDE_DIRS=$(shell rosboost-cfg --include_dirs)
 BOOST_LIBRARY_DIRS=$(shell rosboost-cfg --lib_dirs)
-PYTHON_INSTALL_DIR=$(shell python -c "import sys; from catkin_tools.verbs.catkin_build.common import get_python_install_dir; sys.stdout.write(get_python_install_dir())")
+PYTHON_INSTALL_DIR=lib/python2.7/dist-packages
 
 BUILDDIR=$(shell if [ $(DEBUG) ]; then echo builddebug; else echo build; fi)
 BUILDDIR=$(shell if [ $(DEBUG) ]; then echo builddebug; else echo build; fi)


### PR DESCRIPTION
Modified:
  - 3rdparty/libsiftfast/CMakeLists.txt