### PR TITLE
libcmt with the most recent tag and opt_nm33_uvc including opencv2

### DIFF
--- a/3rdparty/libcmt/CMakeLists.txt
+++ b/3rdparty/libcmt/CMakeLists.txt
@@ -12,7 +12,13 @@ execute_process(COMMAND
 ExternalProject_Add(
   libcmt
   GIT_REPOSITORY https://github.com/delmottea/libCMT.git
-  GIT_TAG e4d7ea42edafe13b1070ef4d595b2d6062d79d1a
+
+  ## OLD TAG
+  # GIT_TAG e4d7ea42edafe13b1070ef4d595b2d6062d79d1a
+
+  ## RECENT TAG
+  GIT_TAG 196c3ce4b4d9a85f71744ce1bd4f44631110e51d
+
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   INSTALL_COMMAND echo "install"
   )

--- a/opt_camera/src/opt_nm33_uvc/opt_nm33_camera.cpp
+++ b/opt_camera/src/opt_nm33_uvc/opt_nm33_camera.cpp
@@ -5,8 +5,10 @@
 
 #include "opt_nm33_camera.h"
 
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
+// #include <opencv/cv.h>
+// #include <opencv/highgui.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/core/core.hpp>
 
 //
 #include <fcntl.h>

--- a/opt_camera/src/opt_nm33_uvc/opt_nm33_camera.h
+++ b/opt_camera/src/opt_nm33_uvc/opt_nm33_camera.h
@@ -5,8 +5,10 @@
 
 #include "opt_nm33_uvc.h"
 
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
+// #include <opencv/cv.h>
+// #include <opencv/highgui.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/core/core.hpp>
 
 class OptNM3xCamera
 {


### PR DESCRIPTION
自分の環境では、
libCMTを最新のタグを指定して、
opt_nm33_uvcでopencv2のヘッダをincludeしないとコンパイルできなかったので、
こんな感じにしました。

あまり深く考えずに直したのでマージする必要ないかもしれませんが、
コンパイル通らない人がいたら参考にしてください程度です。