### PR TITLE
add gawk to run_depends

### DIFF
--- a/3rdparty/downward/package.xml
+++ b/3rdparty/downward/package.xml
@@ -23,5 +23,6 @@
   <build_depend>time</build_depend>
 
   <run_depend>time</run_depend>
+  <run_depend>gawk</run_depend>
 
 </package>


### PR DESCRIPTION
```
[pddl_planner:make] /opt/ros/kinetic/share/downward/src/search/unitcost: 4: /opt/ros/kinetic/share/downward/src/search/unitcost: gawk: not found
```