### PR TITLE
rosping: CMakeLists.txt: fix for cmake 3.5.1

### DIFF
--- a/rosping/CMakeLists.txt
+++ b/rosping/CMakeLists.txt
@@ -37,7 +37,7 @@ install(
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE SETUID
 )
 install(CODE
-  "execute_process(COMMAND sudo -n sh -c \"cd \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION} ; chown root.root rosping; ls -al rosping; chmod 4755 rosping\")
+  "execute_process(COMMAND sudo -n sh -c \"cd \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION} && chown root.root rosping && ls -al rosping && chmod 4755 rosping && ls -al rosping\")
 ")
 
 install(DIRECTORY test


### PR DESCRIPTION
for http://build.ros.org/job/Kbin_uX32__rosping__ubuntu_xenial_i386__binary/4/display/redirect