### PR TITLE
Revert "[opt_camera][OptNM33Camera.cfg] param "4view" does not follow ROS convention"

### DIFF
--- a/opt_camera/cfg/OptNM33Camera.cfg
+++ b/opt_camera/cfg/OptNM33Camera.cfg
@@ -17,7 +17,7 @@ gen.add("mode",       int_t, 0, "Mode",            4,
                                  gen.const("zoom",      int_t, 1, "Zoom mode"),
                                  gen.const("panorama",  int_t, 2, "Panorama mode"),
                                  gen.const("orthogonal",int_t, 3, "Orthogonal mode"),
-                                 gen.const("four_view", int_t, 4, "JSK Robot mode")],
+                                 gen.const("4view",     int_t, 4, "JSK Robot mode")],
                                 "Enum to set the camera mode."))
 
 #


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_3rdparty#91