### PR TITLE
Update collada_urdf repo url

### DIFF
--- a/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
+++ b/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
@@ -2,7 +2,7 @@
 all: urdf_to_collada
 
 GIT_DIR = build/robot_model/src
-GIT_URL = git://github.com/ros/robot_model.git
+GIT_URL = git://github.com/ros/collada_urdf.git
 GIT_REVISION = ${SOURCE_DISTRO}-devel
 PATCH_DIR = $(CURDIR)
 GIT_PATCH = ${PATCH_DIR}/use_assimp_devel.patch ${PATCH_DIR}/collada_urdf_latest_gazebo.patch


### PR DESCRIPTION
Updates the url to the upstream repository containing collada_urdf.

Solves #94

A more robust fix would use rosinstall_generator and rosinstall to download the source. Realistically the collada_urdf package is not going to move again prior to indigo EOL, so the extra effort would be wasted.

cc @mikaelarguedas