### PR TITLE
[libsiftfast] prefer python 2 to find

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: generic
-python:
-  - "2.7"
-compiler:
-  - gcc
 sudo: required
 dist: trusty
 services:

--- a/3rdparty/libsiftfast/patches/01.fix_python_binding.patch
+++ b/3rdparty/libsiftfast/patches/01.fix_python_binding.patch
@@ -11,6 +11,20 @@ Index: CMakeLists.txt
  
  if( Boost_FOUND )
    message(STATUS "found boost version: ${Boost_VERSION}")
+@@ -195,11 +195,11 @@
+ #
+ set(BUILD_SIFTFASTPY)
+ if( Boost_PYTHON_FOUND )
+-  find_package(PythonLibs)
++  find_package(PythonLibs 2)
+ 
+   if( PYTHONLIBS_FOUND OR PYTHON_LIBRARIES )
+ 
+-    find_package(PythonInterp)
++    find_package(PythonInterp 2)
+     if( NOT PYTHON_EXECUTABLE )
+       # look specifically for 2.6
+       FIND_PROGRAM(PYTHON_EXECUTABLE
 @@ -223,7 +223,7 @@
  
      add_definitions(${Boost_CFLAGS})


### PR DESCRIPTION
`libsiftfast` is written for python2 and can be successfully installed with python2.
However this package finds and uses python3 (not 2) first on environment where both python2 and 3 are installed.
(In new travis environment both python2 and 3 seems to be installed)
This issue is fixed in this PR by setting version 2 on `find_package` python.

This should close https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/42 .