### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/jsk_ros_patch/laser_filters_jsk_patch/src/laser_scan_filters.cpp
+++ b/jsk_ros_patch/laser_filters_jsk_patch/src/laser_scan_filters.cpp
@@ -34,5 +34,5 @@
 #include "pluginlib/class_list_macros.h"
 
 
-PLUGINLIB_DECLARE_CLASS(laser_filters, ScanFootObjectFilter, laser_filters::ScanFootObjectFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::ScanFootObjectFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions