### PR TITLE
Revert "use g++ instead of g++-static"

### DIFF
--- a/3rdparty/downward/package.xml
+++ b/3rdparty/downward/package.xml
@@ -18,7 +18,6 @@
   <build_depend>flex</build_depend>
   <build_depend>bison</build_depend>
   <build_depend>gawk</build_depend>
-  <build_depend>g++-static</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>time</build_depend>
 

--- a/3rdparty/downward/package.xml
+++ b/3rdparty/downward/package.xml
@@ -18,7 +18,7 @@
   <build_depend>flex</build_depend>
   <build_depend>bison</build_depend>
   <build_depend>gawk</build_depend>
-  <build_depend>g++</build_depend>
+  <build_depend>g++-static</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>time</build_depend>
 


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_3rdparty#115

we do not have `g++` rosdep keys..