### PR TITLE
Fix install directory of text2wave to ./lib -> ./bin

### DIFF
--- a/3rdparty/voice_text/CMakeLists.txt
+++ b/3rdparty/voice_text/CMakeLists.txt
@@ -59,7 +59,7 @@ install(TARGETS voice_text # do not install vt_dummy target, that should be inst
 )
 
 install(PROGRAMS bin/text2wave
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/bin
 )
 install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
`text2wave` Was wrongly  installed to `CATKIN_PACKAGE_LIB_DESTINATION`

The launch file is assumed that it is installed under `rospack find voice_text`/bin
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/2.1.10/3rdparty/voice_text/launch/voice_text.launch#L29