### PR TITLE
Make sample_respeaker.launch re-usable

### DIFF
--- a/respeaker_ros/launch/sample_respeaker.launch
+++ b/respeaker_ros/launch/sample_respeaker.launch
@@ -1,8 +1,13 @@
 <launch>
+  <!-- publish tf of respeaker -->
   <arg name="publish_tf" default="true"/>
+  <!-- launch sound_play node -->
   <arg name="launch_soundplay" default="true"/>
-  <arg name="audio" default="audio"/>
+  <!-- input speech topic of speech_to_text.py -->
+  <arg name="audio" default="speech_audio"/>
+  <!-- output text topic of speech_to_text.py -->
   <arg name="speech_to_text" default="speech_to_text"/>
+  <!-- langage used in speech_to_text.py -->
   <arg name="language" default="en-US"/>
 
   <node if="$(arg publish_tf)"

--- a/respeaker_ros/launch/sample_respeaker.launch
+++ b/respeaker_ros/launch/sample_respeaker.launch
@@ -1,17 +1,24 @@
 <launch>
+  <arg name="publish_tf" default="true"/>
+  <arg name="launch_soundplay" default="true"/>
+  <arg name="audio" default="audio"/>
+  <arg name="speech_to_text" default="speech_to_text"/>
   <arg name="language" default="en-US"/>
-  
-  <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py"
-        output="screen"/>
 
-  <node name="static_transformer" pkg="tf" type="static_transform_publisher"
+  <node if="$(arg publish_tf)"
+        name="static_transformer" pkg="tf" type="static_transform_publisher"
         args="0 0 0 0 0 0 1 map respeaker_base 100"/>
 
-  <node name="sound_play" pkg="sound_play" type="soundplay_node.py"/>
+  <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py"
+        respawn="true"/>
+
+  <node if="$(arg launch_soundplay)"
+        name="sound_play" pkg="sound_play" type="soundplay_node.py"/>
 
   <node name="speech_to_text" pkg="respeaker_ros" type="speech_to_text.py"
         output="screen">
-    <remap from="audio" to="speech_audio"/>
+    <remap from="audio" to="$(arg audio)"/>
+    <remap from="speech_to_text" to="$(arg speech_to_text)"/>
     <rosparam subst_value="true">
       language: $(arg language)
       self_cancellation: true


### PR DESCRIPTION
In this PR, I add some `arg` to `sample_respeaker.launch` so that we can include this launch file in other launch file.