### PR TITLE
enable to compile libsiftfast with current numpy.get_include()

### DIFF
--- a/3rdparty/libsiftfast/patches/01.fix_python_binding.patch
+++ b/3rdparty/libsiftfast/patches/01.fix_python_binding.patch
@@ -25,7 +25,23 @@ Index: CMakeLists.txt
      if( NOT PYTHON_EXECUTABLE )
        # look specifically for 2.6
        FIND_PROGRAM(PYTHON_EXECUTABLE
-@@ -223,7 +223,7 @@
+@@ -210,12 +210,11 @@
+     if( PYTHON_EXECUTABLE )
+       # get the site-packages directory
+       execute_process(
+-        COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
+-        OUTPUT_VARIABLE _python_sitepackage
++        COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.get_include()"
++        OUTPUT_VARIABLE _python_numpy_include OUTPUT_STRIP_TRAILING_WHITESPACE
+         RESULT_VARIABLE _python_failed)
+       if( ${_python_failed} EQUAL 0 )
+-        string(REGEX REPLACE "[\r\n]" "" _python_sitepackage "${_python_sitepackage}")
+-        set(PYTHON_INCLUDE_PATH ${PYTHON_INCLUDE_PATH} ${_python_sitepackage}/numpy/core/include)
++        set(PYTHON_INCLUDE_PATH ${PYTHON_INCLUDE_PATH} ${__python_numpy_include})
+       else()
+         message(STATUS "failed to get python site-package directory")
+       endif()
+@@ -223,7 +222,7 @@
  
      add_definitions(${Boost_CFLAGS})
      set(CMAKE_REQUIRED_INCLUDES ${PYTHON_INCLUDE_PATH} ${Boost_INCLUDE_DIR} )


### PR DESCRIPTION
rewried version of #151