### PR TITLE
remove debug print line in rostwitter to suppress log

### DIFF
--- a/rostwitter/scripts/tweet.py
+++ b/rostwitter/scripts/tweet.py
@@ -34,7 +34,6 @@ class twitter(object):
 
     def _RequestUrl(self, url, verb, data=None):
         if verb == 'POST':
-            print(data)
             if data.has_key('media'):
                 return requests.post(
                     url,


### PR DESCRIPTION
I remove `print(data)` debug line to suppress log output.