### PR TITLE
[libcmt] Support using OpenCV3 in kinetic

### DIFF
--- a/3rdparty/libcmt/package.xml
+++ b/3rdparty/libcmt/package.xml
@@ -10,11 +10,11 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <build_depend>git</build_depend>
-  <build_depend>libopencv-dev</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>ca-certificates</build_depend>
   <build_depend>openssl</build_depend>
 
-  <run_depend>libopencv-dev</run_depend>
+  <run_depend>cv_bridge</run_depend>
 
  <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_recognition/issues/2474

## Problem

On current master branch, `libcmt` depends on `libopencv-dev`.
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/f2b2bd8ac30a8539a6e099dfe7f1e2830ca12430/3rdparty/libcmt/package.xml#L13

And on kinetic, `libopencv-dev` refers to OpenCV2, so `libcmt` is compiled against OpenCV2 if we install `libcmt` via apt.
```
yutouchimi@libra:~
$ dpkg -l | grep libopencv-dev
ii  libopencv-dev                                    2.4.9.1+dfsg-1.5ubuntu1.1                             amd64        development files for opencv
yutouchimi@libra:~
$ source /opt/ros/kinetic/setup.bash 
yutouchimi@libra:~
$ ldd /opt/ros/kinetic/lib/libcmt.so 
	linux-vdso.so.1 =>  (0x00007ffe1f1cf000)
	libopencv_video.so.2.4 => /usr/lib/x86_64-linux-gnu/libopencv_video.so.2.4 (0x00007f66d4204000)
	libopencv_features2d.so.2.4 => /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4 (0x00007f66d3f68000)
	libopencv_core.so.2.4 => /usr/lib/x86_64-linux-gnu/libopencv_core.so.2.4 (0x00007f66d3b3e000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f66d37bc000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f66d34b3000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f66d329d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f66d2ed3000)
	libopencv_imgproc.so.2.4 => /usr/lib/x86_64-linux-gnu/libopencv_imgproc.so.2.4 (0x00007f66d2a48000)
	libopencv_flann.so.2.4 => /usr/lib/x86_64-linux-gnu/libopencv_flann.so.2.4 (0x00007f66d27e0000)
	libtbb.so.2 => /usr/lib/x86_64-linux-gnu/libtbb.so.2 (0x00007f66d25a3000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f66d2389000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f66d216c000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f66d1f64000)
	libGL.so.1 => /usr/lib/nvidia-410/libGL.so.1 (0x00007f66d1c25000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f66d466b000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f66d1a21000)
	libnvidia-tls.so.410.129 => /usr/lib/nvidia-410/tls/libnvidia-tls.so.410.129 (0x00007f66d181d000)
	libnvidia-glcore.so.410.129 => /usr/lib/nvidia-410/libnvidia-glcore.so.410.129 (0x00007f66cfc47000)
	libX11.so.6 => /usr/lib/x86_64-linux-gnu/libX11.so.6 (0x00007f66cf90d000)
	libXext.so.6 => /usr/lib/x86_64-linux-gnu/libXext.so.6 (0x00007f66cf6fb000)
	libxcb.so.1 => /usr/lib/x86_64-linux-gnu/libxcb.so.1 (0x00007f66cf4d9000)
	libXau.so.6 => /usr/lib/x86_64-linux-gnu/libXau.so.6 (0x00007f66cf2d5000)
	libXdmcp.so.6 => /usr/lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007f66cf0cf000)
```

But when building `jsk_perception`, since it depends on `cv_bridge` (which means `opencv3` is installed with `cv_bridge`), `jsk_perception` finds opencv3.
```
yutouchimi@libra:~
$ ldd /opt/ros/kinetic/lib/libjsk_perception.so 
	linux-vdso.so.1 =>  (0x00007ffe09f08000)
	libcv_bridge.so => /opt/ros/kinetic/lib/libcv_bridge.so (0x00007f2b58cff000)
	libimage_transport.so => /opt/ros/kinetic/lib/libimage_transport.so (0x00007f2b58a7d000)
	libimage_geometry.so => /opt/ros/kinetic/lib/libimage_geometry.so (0x00007f2b58871000)
	libopencv_core3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_core3.so.3.3 (0x00007f2b57938000)
	libopencv_highgui3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_highgui3.so.3.3 (0x00007f2b576f7000)
	libopencv_imgproc3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_imgproc3.so.3.3 (0x00007f2b54e01000)
	libopencv_ml3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_ml3.so.3.3 (0x00007f2b54b31000)
	libopencv_video3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_video3.so.3.3 (0x00007f2b545bb000)
	libopencv_saliency3.so.3.3 => /opt/ros/kinetic/lib/x86_64-linux-gnu/libopencv_saliency3.so.3.3 (0x00007f2b54388000)
	libjsk_recognition_utils.so => /opt/ros/kinetic/lib/libjsk_recognition_utils.so (0x00007f2b540cc000)
... (too long, so cut)...
	libcmt.so => /opt/ros/kinetic/lib/libcmt.so (0x00007f2b51585000)
... (too long, so cut)...
```

As you can see, `jsk_perception` is also linked to `libcmt`, which was compiled against opencv2.


__Here goes the main part.__

`libcmt` is linked from `jsk_perception` because `libcmt/CMT.h` is included in `jsk_perception/consensus_tracking.h`, and build of `jsk_perception` succeeds with opencv3.

But on runtime, `jsk_perception/ConsensusTracking` process dies as reported in https://github.com/jsk-ros-pkg/jsk_recognition/issues/2474 .
The node tries to call `cmt.initialise` (assuming compiled against OpenCV3) but segmentation fault occurs because `libcmt` is actually compiled against OpenCV2.

Below is a part of gdb backtrace.
```
#0  0x00007fffcb6a1ef7 in cv::BriskLayer::BriskLayer(cv::Mat const&, float, float) ()
   from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#1  0x00007fffcb6a45eb in cv::BriskScaleSpace::constructPyramid(cv::Mat const&) ()
   from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#2  0x00007fffcb6abc1b in cv::BRISK::computeKeypointsNoOrientation(cv::_InputArray const&, cv::_InputArray const&, std::vector<cv::KeyPoint, std::allocator<cv::KeyPoint> >&) const () from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#3  0x00007fffcb6ad92b in cv::BRISK::operator()(cv::_InputArray const&, cv::_InputArray const&, std::vector<cv::KeyPoint, std::allocator<cv::KeyPoint> >&) const () from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#4  0x00007fffcb6ad9b1 in cv::BRISK::detectImpl(cv::Mat const&, std::vector<cv::KeyPoint, std::allocator<cv::KeyPoint> >&, cv::Mat const&) const () from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#5  0x00007fffcb708d0d in cv::FeatureDetector::detect(cv::Mat const&, std::vector<cv::KeyPoint, std::allocator<cv::KeyPoint> >&, cv::Mat const&) const () from /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.2.4
#6  0x00007fffd14fd02d in CMT::initialise(cv::Mat, cv::Point_<float>, cv::Point_<float>) () from /opt/ros/kinetic/lib/libcmt.so
#7  0x00007fffdbba4a50 in jsk_perception::ConsensusTracking::setInitialWindow (this=0x10bf7f0, image_msg=..., poly_msg=...)
    at /home/yutouchimi/Projects/pr2_subway/src/jsk-ros-pkg/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:105
```

## How to solve this

Change dependency in `libcmt`: `libopencv-dev` -> `cv_bridge` to support using OpenCV3 in kinetic.
This can fix the problem because `cv_bridge` installs not `libopencv-dev` but `opencv3` on kinetic, but this seems a bit dirty method.
@k-okada What do you think?

cc. @taichiH @pazeshun 