### PR TITLE
[sesame_ros] Add dependency for building cryptograpy

### DIFF
--- a/sesame_ros/package.xml
+++ b/sesame_ros/package.xml
@@ -11,6 +11,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>catkin_virtualenv</build_depend>
+  <build_depend>libffi-dev</build_depend>
+  <build_depend>libssl-dev</build_depend>
   <build_depend>message_generation</build_depend>
 
   <exec_depend>message_runtime</exec_depend>

--- a/sesame_ros/package.xml
+++ b/sesame_ros/package.xml
@@ -4,8 +4,10 @@
   <version>2.1.14</version>
   <description>ROS API for Sesame smart lock</description>
 
+  <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
   <maintainer email="uchimi@jsk.imi.i.u-tokyo.ac.jp">Yuto Uchimi</maintainer>
   <author email="uchimi@jsk.imi.i.u-tokyo.ac.jp">Yuto Uchimi</author>
+
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/sesame_ros/package.xml
+++ b/sesame_ros/package.xml
@@ -10,6 +10,8 @@
 
   <license>BSD</license>
 
+  <url type="website">http://ros.org/wiki/sesame_ros</url>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>catkin_virtualenv</build_depend>


### PR DESCRIPTION
Build of sesame_ros (released in kinetic) is failing on ROS build farm on some architectures.
http://build.ros.org/job/Kbin_uX32__sesame_ros__ubuntu_xenial_i386__binary/
http://build.ros.org/job/Kbin_uxhf_uXhf__sesame_ros__ubuntu_xenial_armhf__binary/
http://build.ros.org/job/Kbin_uxv8_uXv8__sesame_ros__ubuntu_xenial_arm64__binary/

i386:
```
08:08:12 New python executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-i686-linux-gnu/venv/bin/python2
08:08:12 Also creating executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-i686-linux-gnu/venv/bin/python
08:08:12 Installing setuptools, pkg_resources, pip, wheel...done.
08:08:15 Running virtualenv with interpreter /usr/bin/python2
08:08:24   Failed building wheel for cryptography
08:08:25 Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
08:08:25 Error, clearing virtualenv and retrying: Command '['/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-i686-linux-gnu/venv/bin/python', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-i686-linux-gnu/venv/bin/pip', 'install', '-qq', '-r', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-i686-linux-gnu/generated_requirements.txt']' returned non-zero exit status 1
```

armhf:
```
10:10:50 New python executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/bin/python2
10:10:50 Also creating executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/bin/python
10:10:50 Installing setuptools, pkg_resources, pip, wheel...done.
10:11:24 Running virtualenv with interpreter /usr/bin/python2
10:12:32 Command "/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/bin/python /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/local/lib/python2.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-dHaIZd/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools>=40.6.0 wheel "cffi>=1.8,!=1.11.3; platform_python_implementation != 'PyPy'"" failed with error code 1 in None
10:12:32 Error, clearing virtualenv and retrying: Command '['/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/bin/python', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/venv/bin/pip', 'install', '-qq', '-r', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-arm-linux-gnueabihf/generated_requirements.txt']' returned non-zero exit status 1
```

arm64:
```
09:30:58 New python executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/bin/python2
09:30:58 Also creating executable in /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/bin/python
09:30:58 Installing setuptools, pkg_resources, pip, wheel...done.
09:31:10 Running virtualenv with interpreter /usr/bin/python2
09:31:40 Command "/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/bin/python /tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/local/lib/python2.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-R8gXZm/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools>=40.6.0 wheel "cffi>=1.8,!=1.11.3; platform_python_implementation != 'PyPy'"" failed with error code 1 in None
09:31:40 Error, clearing virtualenv and retrying: Command '['/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/bin/python', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/venv/bin/pip', 'install', '-qq', '-r', '/tmp/binarydeb/ros-kinetic-sesame-ros-2.1.14/obj-aarch64-linux-gnu/generated_requirements.txt']' returned non-zero exit status 1
```

This seems the failure of `pip install`, especially `cffi` and `cryptography`.
According to https://stackoverflow.com/questions/22073516/failed-to-install-python-cryptography-package-with-pip-and-setup-py, this can be solved by installing `libssl-dev` and `libffi-dev` before running `pip install`.

I tried to test this PR on virtual machine (QEMU), but didn't know how to connect to the Internet from guest OS... :(
Maybe some review is needed.