### PR TITLE
[respeaker_ros] add pixel-ring in run_depend of respeaker_ros

### DIFF
--- a/respeaker_ros/package.xml
+++ b/respeaker_ros/package.xml
@@ -16,6 +16,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>python-numpy</run_depend>
+  <run_depend>python-pixel-ring-pip</run_depend>
   <run_depend>python-pyaudio</run_depend>
   <run_depend>python-pyusb-pip</run_depend>
   <run_depend>python-speechrecognition-pip</run_depend>


### PR DESCRIPTION
add `python-pixel-ring-pip` in `respeaker_ros/package.xml`