### PR TITLE
[respeaker_ros] install config dir in respeaker_ros

### DIFF
--- a/respeaker_ros/CMakeLists.txt
+++ b/respeaker_ros/CMakeLists.txt
@@ -9,7 +9,7 @@ generate_dynamic_reconfigure_options(
 
 catkin_package()
 
-install(DIRECTORY scripts launch
+install(DIRECTORY config scripts launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS)
 


### PR DESCRIPTION
install `config` dir in `respeaker_ros`
the config dir is required to install `udev` file