### PR TITLE
[ros_speech_recognition] Enable multi channel audio recognition

### DIFF
--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -112,9 +112,9 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
   Depth of audio signal
   
-* `~channels` (`Int`, default: `1`)
+* `~n_channel` (`Int`, default: `1`)
 
-  Channels of audio data (e.g. 1: mono, 2: stereo)
+  Total number of channels in audio data (e.g. 1: mono, 2: stereo)
   
 * `~sample_rate` (`Int`, default: `16000`)
 

--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -84,6 +84,14 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
   Seconds after an internal operation (e.g., an API request) starts before it times out
   
+* `~listen_timeout` (`Double`, default: `0.0`)
+
+  The maximum number of seconds that this will wait for a phrase to start before giving up
+  
+* `~phrase_time_limit` (`Double`, default: `10.0`)
+
+  The maximum number of seconds that this will allow a phrase to continue before stopping and returning the part of the phrase processed before the time limit was reached
+  
 * `~phrase_threshold` (`Double`, default: `0.3`)
 
   Minimum seconds of speaking audio before we consider the speaking audio a phrase
@@ -96,13 +104,25 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
   Seconds of waiting for speech
 
+* `~audio_topic` (`String`, default: `audio`)
+
+  Topic name of input audio data
+  
 * `~depth` (`Int`, default: `16`)
 
   Depth of audio signal
   
+* `~channels` (`Int`, default: `1`)
+
+  Channels of audio data (e.g. 1: mono, 2: stereo)
+  
 * `~sample_rate` (`Int`, default: `16000`)
 
   Sample rate of audio signal
+  
+* `~buffer_size` (`Int`, default: `10240`)
+
+  Maximum buffer size to store audio data for speech recognition
   
 * `~start_signal` (`String`, default: `/usr/share/sounds/ubuntu/stereo/bell.ogg`)
 

--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -3,7 +3,7 @@
   <arg name="launch_audio_capture" default="true" />
 
   <arg name="audio_topic" default="/audio" />
-  <arg name="channels" default="1" />
+  <arg name="n_channel" default="1" />
   <arg name="depth" default="16" />
   <arg name="sample_rate" default="16000" />
   <arg name="device" default="" />
@@ -24,7 +24,7 @@
         respawn="true">
     <rosparam subst_value="true">
       format: wave
-      channels: $(arg channels)
+      channels: $(arg n_channel)
       depth: $(arg depth)
       sample_rate: $(arg sample_rate)
       device: $(arg device)
@@ -37,7 +37,7 @@
         output="screen">
     <rosparam subst_value="true">
       audio_topic: $(arg audio_topic)
-      channels: $(arg channels)
+      n_channel: $(arg n_channel)
       depth: $(arg depth)
       sample_rate: $(arg sample_rate)
       engine: $(arg engine)

--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -3,6 +3,7 @@
   <arg name="launch_audio_capture" default="true" />
 
   <arg name="audio_topic" default="/audio" />
+  <arg name="channels" default="1" />
   <arg name="depth" default="16" />
   <arg name="sample_rate" default="16000" />
   <arg name="device" default="" />
@@ -23,7 +24,7 @@
         respawn="true">
     <rosparam subst_value="true">
       format: wave
-      channels: 1
+      channels: $(arg channels)
       depth: $(arg depth)
       sample_rate: $(arg sample_rate)
       device: $(arg device)
@@ -36,6 +37,7 @@
         output="screen">
     <rosparam subst_value="true">
       audio_topic: $(arg audio_topic)
+      channels: $(arg channels)
       depth: $(arg depth)
       sample_rate: $(arg sample_rate)
       engine: $(arg engine)

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -73,6 +73,9 @@ class ROSAudio(SR.AudioSource):
             self.target_channel = min(self.n_channel - 1, max(0, target_channel))
             self.sub_audio = rospy.Subscriber(
                 topic_name, AudioData, self.audio_cb)
+            self.type_code = {}
+            for code in ['b', 'h', 'i', 'l']:
+                self.type_code[array.array(code).itemsize] = code
 
         def read_once(self, size):
             with self.lock:
@@ -94,12 +97,7 @@ class ROSAudio(SR.AudioSource):
 
         def audio_cb(self, msg):
             with self.lock:
-                if self.depth == 8:
-                    dtype = 'b'  # int8
-                if self.depth == 16:
-                    dtype = 'h'  # int16
-                if self.depth == 32:
-                    dtype = 'l'  # int32
+                dtype = self.type_code[self.depth/8]
                 # take out target_channel channel data from multi channel data
                 data = array.array(dtype, bytes(msg.data)).tolist()
                 chan_data = data[self.target_channel::self.n_channel]


### PR DESCRIPTION
In this pull request, I enable multi channel audio recognition.

if audio topic's channel >= 2, single channel data is taken out from multi channel data.
This feature is based on `respeaker_node.py`, in which 1 channel audio data is taken out from 4 channel respeaker audio.
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/75e5e7ed0f650bffd1d434e522a72466be9735f7/respeaker_ros/scripts/respeaker_node.py#L278-L280

I was careful not to use numpy, which is additional dependency.