### PR TITLE
[dialogflow_task_executive] accepct full name of app name for dialogflow action

### DIFF
--- a/dialogflow_task_executive/README.md
+++ b/dialogflow_task_executive/README.md
@@ -55,11 +55,12 @@ Please read [app_manager](https://github.com/PR2/app_manager/) for more detailed
 
 For your new task, create new Intent as below.
 
-`Action` section, you must name camel-cased name of your `app_manager` app.
+`Action` section, you can set full name (`<package name>/<app name>`), app name or camel-cased name of your `app_manager` app.
+The Full name (`<package name>/<app name>`) is recommended to avoid name confliction.
 
-If your app is registered as `your_package/your_demo`, you need to set `YourDemo` in `Action` section.
+If your app is registered as `your_package/your_demo`, you need to set `your_package/your_demo`, `your_demo` or  `YourDemo` in `Action` section.
 
-(i.e. App name: `detect_cans_in_fridge201202/pick_object` -> Dialogflow Action: `PickObject`)
+(i.e. App name: `detect_cans_in_fridge201202/pick_object` -> Dialogflow Action: `detect_cans_in_fridge201202/pick_object`, `pick_object` or `PickObject`)
 
 ![](./img/dialogflow_intent.png)
 

--- a/dialogflow_task_executive/node_scripts/task_executive.py
+++ b/dialogflow_task_executive/node_scripts/task_executive.py
@@ -212,7 +212,7 @@ class TaskExecutive(object):
         else:
             action = camel_to_snake(msg.action)
             for app_name in self.app_manager.available_apps:
-                if action == app_name.split('/')[1]:
+                if action == app_name or action == app_name.split('/')[1]:
                     action = app_name
                     break
         if action not in self.app_manager.available_apps:


### PR DESCRIPTION
with this PR, dialogflow can use full name of app name (`<package name>/<app name>`) for dialoglow action.

I'm testing this PR on pr1040 now.

![dialogflow](https://user-images.githubusercontent.com/9300063/88057940-c4c88100-cb9d-11ea-995c-73b906fbb1cd.png)
