### PR TITLE
Mistakes I found when I tried to use respeaker_ros on hirovision

### DIFF
--- a/respeaker_ros/README.md
+++ b/respeaker_ros/README.md
@@ -63,7 +63,7 @@ A ROS Package for Respeaker Mic Array
 1. Run executables
 
     ```bash
-    roslaunch respeaker_ros respeaker.launch
+    roslaunch respeaker_ros sample_respeaker.launch
     rostopic echo /sound_direction     # Result of DoA
     rostopic echo /sound_localization  # Result of DoA as Pose
     rostopic echo /is_speeching        # Result of VAD

--- a/respeaker_ros/package.xml
+++ b/respeaker_ros/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>flac</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>speech_recognition_msgs</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python3-numpy</exec_depend>


### PR DESCRIPTION
1. Change the name of sample launch file in README.md.
2. Add speech_recognition_msgs to package.xml because it is used in speech_to_text.py
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/master/respeaker_ros/scripts/speech_to_text.py#L15