### PR TITLE
[voice_text] Support other speakers than SAYAKA and new directory tree

### DIFF
--- a/3rdparty/voice_text/.gitignore
+++ b/3rdparty/voice_text/.gitignore
@@ -1,0 +1,1 @@
+src/voice_text.cpp

--- a/3rdparty/voice_text/CMakeLists.txt
+++ b/3rdparty/voice_text/CMakeLists.txt
@@ -20,12 +20,32 @@ generate_messages()
 
 catkin_package(CATKIN_DEPENDS message_runtime)
 
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-  set(VT_LIB_ARCH x86_32/)
-elseif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
-  set(VT_LIB_ARCH x86_64/)
+file(GLOB VT_ROOT /usr/vt/*/*)
+if(NOT VT_ROOT)
+  message(WARNING "VoiceText directory should be /usr/vt/*/* (e.g., /usr/vt/sayaka/M16) but is not found")
+  set(VT_ROOT /usr/vt/sayaka/M16)  # default value for following configure_file
+else()
+  if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+    set(VT_LIB_PATH_OLD ${VT_ROOT}/bin/x86_32/RAMIO/libvt_jpn.so)  # e.g., /usr/vt/sayaka/M16/bin/x86_32/RAMIO/libvt_jpn.so
+    set(VT_LIB_PATH_NEW ${VT_ROOT}/bin/LINUX32_GLIBC3/RAMIO/libvt_jpn.so)  # e.g., /usr/vt/risa/H16/bin/LINUX32_GLIBC3/RAMIO/libvt_jpn.so
+  elseif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+    set(VT_LIB_PATH_OLD ${VT_ROOT}/bin/x86_64/RAMIO/libvt_jpn.so)  # e.g., /usr/vt/sayaka/M16/bin/x86_64/RAMIO/libvt_jpn.so
+    set(VT_LIB_PATH_NEW ${VT_ROOT}/bin/LINUX64_GLIBC3/RAMIO/libvt_jpn.so)  # e.g., /usr/vt/risa/H16/bin/LINUX64_GLIBC3/RAMIO/libvt_jpn.so
+  endif()
+  if(EXISTS ${VT_LIB_PATH_OLD})
+    set(VT_LIB_PATH ${VT_LIB_PATH_OLD})
+  else()
+    if(EXISTS ${VT_LIB_PATH_NEW})
+      set(VT_LIB_PATH ${VT_LIB_PATH_NEW})
+    endif()
+  endif()
+  if(VT_LIB_PATH)
+    message(WARNING "VoiceText library is found at ${VT_LIB_PATH}")
+  else()
+    message(WARNING "VoiceText library is not found at ${VT_LIB_PATH_OLD} or ${VT_LIB_PATH_NEW}")
+  endif()
 endif()
-set(VT_LIB_PATH /usr/vt/sayaka/M16/bin/${VT_LIB_ARCH}RAMIO/libvt_jpn.so)
+configure_file(src/voice_text.cpp.in ${PROJECT_SOURCE_DIR}/src/voice_text.cpp)
 
   include_directories(
     ${Boost_INCLUDE_DIRS}
@@ -35,8 +55,8 @@ set(VT_LIB_PATH /usr/vt/sayaka/M16/bin/${VT_LIB_ARCH}RAMIO/libvt_jpn.so)
   add_dependencies(voice_text ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
   set_target_properties(voice_text PROPERTIES COMPILE_FLAGS -D_REENTRANT)
 
-if(NOT EXISTS ${VT_LIB_PATH})
-  message(WARNING "VoiceText Library not found at ${VT_LIB_PATH}. building dummy library.")
+if(NOT VT_LIB_PATH)
+  message(WARNING "Building dummy library")
   add_library(vt_dummy src/dummy/vt_dummy.cpp)
   set_target_properties(vt_dummy PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
   set_target_properties(vt_dummy PROPERTIES LIBRARY_OUTPUT_NAME vt_jpn)

--- a/3rdparty/voice_text/README.md
+++ b/3rdparty/voice_text/README.md
@@ -55,7 +55,7 @@ Robot says "Hello!"
 
 ### Parameters
 
-* `~db_path` (String, default: `"/var/vt/sayaka/M16"`)
+* `~db_path` (String, default: path found at build time (e.g., `"/var/vt/sayaka/M16"`))
 
   Path to VoiceText database directory.
 

--- a/3rdparty/voice_text/launch/voice_text.launch
+++ b/3rdparty/voice_text/launch/voice_text.launch
@@ -13,7 +13,7 @@
         machine="$(arg voice_text_machine)">
     <remap from="text_to_speech" to="voice_text/text_to_speech" />
     <rosparam>
-      db_path: /usr/vt/sayaka/M16
+      # db_path: /usr/vt/sayaka/M16  # Commented out to support other speakers than SAYAKA
       pitch: 100
       speed: 100
       volume: 100

--- a/3rdparty/voice_text/src/voice_text.cpp.in
+++ b/3rdparty/voice_text/src/voice_text.cpp.in
@@ -21,7 +21,7 @@
 #ifdef USE_DUMMY_INCLUDE
 #include "dummy/vt_dummy.h"
 #else
-#include "/usr/vt/sayaka/M16/inc/vt_jpn.h"
+#include "@VT_ROOT@/inc/vt_jpn.h"
 #endif
 
 namespace fs = boost::filesystem;
@@ -32,7 +32,8 @@ public:
   typedef voice_text::VoiceTextConfig Config;
 
   VoiceText() : nh_(), pnh_("~"), db_path_(""), license_path_(""), dyn_srv_(pnh_) {
-    pnh_.param<std::string>("db_path", db_path_, "/usr/vt/sayaka/M16");
+    pnh_.param<std::string>("db_path", db_path_, "@VT_ROOT@");
+    pnh_.setParam("db_path", db_path_);  // for backward compatibility (db_path is usually set previously)
     pnh_.param<std::string>("license_path", license_path_, "");
 
     dynamic_reconfigure::Server<Config>::CallbackType f =


### PR DESCRIPTION
We bought a new VoiceText SDK whose speaker is RISA and tried to use voice_text package with that SDK.
However, current voice_text assumes that the speaker is SAYAKA:
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/bfce3ffc368bfb9367bd429a289aee36c1bbc0d2/3rdparty/voice_text/CMakeLists.txt#L28
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/bfce3ffc368bfb9367bd429a289aee36c1bbc0d2/3rdparty/voice_text/src/voice_text.cpp#L24
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/bfce3ffc368bfb9367bd429a289aee36c1bbc0d2/3rdparty/voice_text/src/voice_text.cpp#L35
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/bfce3ffc368bfb9367bd429a289aee36c1bbc0d2/3rdparty/voice_text/launch/voice_text.launch#L16
In addition, the new VoiceText SDK has a different directory tree from the old one (e.g., `/usr/vt/<SPEAKER>/<NUMBER>/bin/x86_64/RAMIO/libvt_jpn.so` was moved to `/usr/vt/<SPEAKER>/<NUMBER>/bin/LINUX64_GLIBC3/RAMIO/libvt_jpn.so`).

This PR enables to support other speakers than SAYAKA and the new directory tree.
The old directory tree remains supported.

cc. @MiyabiTane @knorth55 