### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - CHECK_PYTHON3_COMPILE=true
     - ROS_DISTRO=indigo  USE_DEB=true
     - ROS_DISTRO=kinetic USE_DEB=true
-    - ROS_DISTRO=kinetic USE_DEB=true DOCKER_IMAGE=i386/ubuntu:16.04
+    - ROS_DISTRO=kinetic USE_DEB=true DOCKER_IMAGE=i386/ubuntu:16.04 ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src --skip-keys=python-google-cloud-texttospeech-pip --skip-keys=python-dialogflow-pip"  # Skip installation of grpcio by pip because it causes error
     - ROS_DISTRO=melodic USE_DEB=true
     - ROS_DISTRO=noetic  USE_DEB=true
     - ROS_DISTRO=noetic  USE_DEB=false

--- a/ros_speech_recognition/CMakeLists.txt
+++ b/ros_speech_recognition/CMakeLists.txt
@@ -14,7 +14,13 @@ generate_dynamic_reconfigure_options(
 
 catkin_package()
 
-catkin_generate_virtualenv()
+if($ENV{ROS_DISTRO} STREQUAL "noetic")
+  catkin_generate_virtualenv(
+    PYTHON_INTERPRETER python3.8
+    )
+else()
+  catkin_generate_virtualenv()
+endif()
 
 catkin_install_python(
   PROGRAMS scripts/speech_recognition_node.py

--- a/ros_speech_recognition/CMakeLists.txt
+++ b/ros_speech_recognition/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package()
 
 if($ENV{ROS_DISTRO} STREQUAL "noetic")
   catkin_generate_virtualenv(
-    PYTHON_INTERPRETER python3.8
+    PYTHON_INTERPRETER python3
     )
 else()
   catkin_generate_virtualenv()

--- a/ros_speech_recognition/src/ros_speech_recognition/__init__.py
+++ b/ros_speech_recognition/src/ros_speech_recognition/__init__.py
@@ -1,5 +1,1 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Author: furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
-
-from client import SpeechRecognitionClient
+from ros_speech_recognition.client import SpeechRecognitionClient  # NOQA


### PR DESCRIPTION
### For noetic test
I use python 3 in virtualenv in ros_speech_recognition to avoid the below error.
```
[ros_speech_recognition:make] Traceback (most recent call last):
[ros_speech_recognition:make]   File "/home/travis/ros/ws_jsk_3rdparty/src/jsk_3rdparty/ros_speech_recognition/scripts/speech_recognition_node.py", line 5, in <module>
[ros_speech_recognition:make]     import actionlib
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/__init__.py", line 28, in <module>
[ros_speech_recognition:make]     from actionlib.action_client import *
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/action_client.py", line 56, in <module>
[ros_speech_recognition:make]     import rospy
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/__init__.py", line 49, in <module>
[ros_speech_recognition:make]     from .client import spin, myargv, init_node, \                                                                            
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/client.py", line 60, in <module>                                                                            
[ros_speech_recognition:make]     import rospy.impl.init                                                                            
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/init.py", line 54, in <module>                                                                            
[ros_speech_recognition:make]     from .tcpros import init_tcpros                                                                            
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/tcpros.py", line 45, in <module>                                                                            
[ros_speech_recognition:make]     import rospy.impl.tcpros_service                                                                            
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/tcpros_service.py", line 54, in <module>                                                                            
[ros_speech_recognition:make]     from rospy.impl.tcpros_base import TCPROSTransport, TCPROSTransportProtocol, \                                                                            
[ros_speech_recognition:make]   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/tcpros_base.py", line 160                                                                            
[ros_speech_recognition:make]     (e_errno, msg, *_) = e.args                                                                            
[ros_speech_recognition:make]                    ^                                                                            
[ros_speech_recognition:make] SyntaxError: invalid syntax
```

In addition, I corrected path writing style in `__init__.py`.
Relative path writing style has changed between python 2 and 3.
https://stackoverflow.com/questions/12172791/changes-in-import-statement-python3

### For i386:kinetic test
I skip `python-google-cloud-texttospeech-pip` and `python-dialogflow-pip` install at i386:kinetic travis.
This is because these packages depend on `grpcio` package, but the latest `grpcio` cannot be installed on i386:kinetic.

I hope these commits fix the recent travis failures.
Thank you very much for your help, @pazeshun , @knorth55 