### PR TITLE
[ros_speech_recognition] Add doc to speech_recognition.launch

### DIFF
--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -1,15 +1,15 @@
 <launch>
-  <arg name="launch_sound_play" default="true" />
-  <arg name="launch_audio_capture" default="true" />
+  <arg name="launch_sound_play" default="true" doc="Launch sound_play node to speak" />
+  <arg name="launch_audio_capture" default="true" doc="Launch audio_capture node to publish audio topic from microphone" />
 
-  <arg name="audio_topic" default="/audio" />
-  <arg name="n_channel" default="1" />
-  <arg name="depth" default="16" />
-  <arg name="sample_rate" default="16000" />
-  <arg name="device" default="" />
-  <arg name="engine" default="Google" />
-  <arg name="language" default="en-US" />
-  <arg name="continuous" default="false" />
+  <arg name="audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
+  <arg name="n_channel" default="1" doc="Number of channels of audio topic and microphone. $ pactl list short sinks" />
+  <arg name="depth" default="16" doc="Bit depth of audio topic and microphone. $ pactl list short sinks" />
+  <arg name="sample_rate" default="16000" doc="Frame rate of audio topic and microphone. $ pactl list short sinks"/>
+  <arg name="device" default="" doc="Card and device number of microphone (e.g. hw:0,0). $ arecord -l" />
+  <arg name="engine" default="Google" doc="Speech to text engine." />
+  <arg name="language" default="en-US" doc="Speech to text language. For Japanese, set ja-JP." />
+  <arg name="continuous" default="false" doc="If false, /speech_recognition service is published. If true, /Tablet/voice topic is published." />
 
   <!-- sound play -->
   <node name="sound_play" pkg="sound_play" type="soundplay_node.py"


### PR DESCRIPTION
I add doc to `speech_recognition.launch` args.

```bash
$ roslaunch ros_speech_recognition speech_recognition.launch --ros-args
Required Arguments:
  device: Card and device number of microphone (e.g. hw:0,0). $ arecord -l
Optional Arguments:
  audio_topic (default "/audio"): Name of audio topic captured from microphone
  continuous (default "false"): If false, /speech_recognition service is published. If true, /Tablet/voice topic is published.
  depth (default "16"): Bit depth of audio topic and microphone. $ pactl list short sinks
  engine (default "Google"): Speech to text engine.
  language (default "en-US"): Speech to text language. For Japanese, set ja-JP.
  launch_audio_capture (default "true"): Launch audio_capture node to publish audio topic from microphone
  launch_sound_play (default "true"): Launch sound_play node to speak
  n_channel (default "1"): Number of channels of audio topic and microphone. $ pactl list short sinks
  sample_rate (default "16000"): Frame rate of audio topic and microphone. $ pactl list short sinks
```

cc @softyanija