### PR TITLE
Replace numbers and alphabets in text file for aques_talk to speak numbers

### DIFF
--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -34,3 +34,13 @@ client.say('Hello', voice='en')
 
 
 ```
+
+
+### Limitations on input strings
+```
+Wrong -> Correct
+20時です -> 20じです # Kanji is sometimes mispronounced.
+fetch15 -> フェッチ15 # fetch is pronounced as エフ、イー、ティー、シー、エイチ
+73B2 -> 7,3,B,2 # 73B2 is pronounced as ななじゅうさんビーに
+私の名前は -> 私の名前わ
+```

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     os.system("nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
+               sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))
     os.system("cat %s 1>&2"%(jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     os.system("nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
-               sed -e 's/\([0-9][0-9]*\)/<NUMK VAL=\\1>/g' > \
+               sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))
     os.system("cat %s 1>&2"%(jptext_file))
     os.system("rosrun aques_talk SampleTalk -p %s -o %s %s"%(phont_file, output_file, jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -33,7 +33,8 @@ if __name__ == '__main__':
     # escape invalid code
     os.system("nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
-               sed -e 's/．/。/g' | sed -e 's/\./。/g' > \
+               sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
+               sed -e 's/\([0-9][0-9]*\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))
     os.system("cat %s 1>&2"%(jptext_file))
     os.system("rosrun aques_talk SampleTalk -p %s -o %s %s"%(phont_file, output_file, jptext_file))


### PR DESCRIPTION
I replace numbers in text file for aques_talk to speak numbers. I add sed command like following.
```
$ echo こんにちわ | sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\1>/g' | sed -e 's/\([0-9]\+\)/<NUMK VAL=\1>/g'
こんにちわ
$ echo 私の名前わ、fetch15です。 | sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\1>/g' | sed -e 's/\([0-9]\+\)/<NUMK VAL=\1>/g'
私の名前わ、<ALPHA VAL=fetch><NUMK VAL=15>です。
```

For example, 
```bash
$ roslaunch aques_talk aques_talk.launch
$ rostopic pub /robotsound_jp  sound_play/SoundRequest "{sound: -3, command: 1, volume: 10.0, arg: '私の名前わ、fetch15です。', arg2: ''}"
```