### PR TITLE
[gdrive_ros] fix typo and add roslaunch test

### DIFF
--- a/gdrive_ros/CMakeLists.txt
+++ b/gdrive_ros/CMakeLists.txt
@@ -31,3 +31,8 @@ install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest roslaunch)
+  roslaunch_add_file_check(launch/gdrive_server.launch)
+endif()

--- a/gdrive_ros/launch/gdrive_server.launch
+++ b/gdrive_ros/launch/gdrive_server.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="settings_yaml" default="$(env GOOGLE_DRIVE_SETTINGS_YAML)" />
-  <arg name="respawm" default="false" />
+  <arg name="respawn" default="false" />
 
   <node name="gdrive_server" pkg="gdrive_ros" type="gdrive_server_node.py"
         output="screen" respawn="$(arg respawn)">

--- a/gdrive_ros/launch/gdrive_server.launch
+++ b/gdrive_ros/launch/gdrive_server.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="settings_yaml" default="$(env GOOGLE_DRIVE_SETTINGS_YAML)" />
+  <arg name="settings_yaml" default="$(optenv GOOGLE_DRIVE_SETTINGS_YAML /var/lib/robot/pydrive_settings.yaml)" />
   <arg name="respawn" default="false" />
 
   <node name="gdrive_server" pkg="gdrive_ros" type="gdrive_server_node.py"


### PR DESCRIPTION
moved from #231 

this PR fixes the typo.
I also add `roslaunch` test recommended by @708yamaguchi in https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/231#pullrequestreview-563448623

@sktometometo thank you for fixing the typo.