### PR TITLE
[gdrive_ros] add node_name arg in gdrive_server.launch

### DIFF
--- a/gdrive_ros/launch/gdrive_server.launch
+++ b/gdrive_ros/launch/gdrive_server.launch
@@ -1,8 +1,9 @@
 <launch>
   <arg name="settings_yaml" default="$(optenv GOOGLE_DRIVE_SETTINGS_YAML /var/lib/robot/pydrive_settings.yaml)" />
   <arg name="respawn" default="false" />
+  <arg name="node_name" default="gdrive_server" />
 
-  <node name="gdrive_server" pkg="gdrive_ros" type="gdrive_server_node.py"
+  <node name="$(arg node_name)" pkg="gdrive_ros" type="gdrive_server_node.py"
         output="screen" respawn="$(arg respawn)">
     <rosparam subst_value="true">
       settings_yaml: $(arg settings_yaml)


### PR DESCRIPTION
I add `node_name` argument to `gdrive_server.launch` to avoid node's name collision