### PR TITLE
update jsk_travis to 0.5.18, fix get-pip.py problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     - env: ROS_DISTRO=noetic  USE_DEB=true
 script:
   - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then python3 -m compileall .; exit $?; fi
+  - if [ "$ROS_DISTRO" == "indigo" ]; then export BEFORE_SCRIPT="sudo pip install virtualenv==15.1.0; $BEFORE_SCRIPT"; fi
   - source .travis/travis.sh
 notifications:
   email:


### PR DESCRIPTION
To pass travis tests in jsk_3rdparty
https://travis-ci.com/github/jsk-ros-pkg/jsk_3rdparty/builds/217741761

```
+ sudo -E python
+ curl https://bootstrap.pypa.io/get-pip.py
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1884k  100 1884k    0     0  4795k      0 --:--:-- --:--:-- --:--:-- 4795k

Traceback (most recent call last):
  File "<stdin>", line 24244, in <module>
  File "<stdin>", line 199, in main
  File "<stdin>", line 82, in bootstrap
  File "/tmp/tmpMylbEX/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```
