### PR TITLE
[respeaker_ros] fix default sound_play action name of speech_to_text.py

### DIFF
--- a/respeaker_ros/scripts/speech_to_text.py
+++ b/respeaker_ros/scripts/speech_to_text.py
@@ -28,7 +28,7 @@ class SpeechToText(object):
         self.tts_tolerance = rospy.Duration.from_sec(
             rospy.get_param("~tts_tolerance", 1.0))
         tts_action_names = rospy.get_param(
-            '~tts_action_names', ['soundplay'])
+            '~tts_action_names', ['sound_play'])
 
         self.recognizer = SR.Recognizer()
 


### PR DESCRIPTION
Fix default sound_play action name of speech_to_text.py.
By this pr, sample_respeaker.launch will work correctly.