### PR TITLE
[Wait for Upstream] [respeaker_ros] Restrict pyusb to versions compatible with Python 2

### DIFF
--- a/respeaker_ros/package.xml
+++ b/respeaker_ros/package.xml
@@ -18,10 +18,10 @@
   <exec_depend>speech_recognition_msgs</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python3-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
   <exec_depend>python-pixel-ring-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pyaudio</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python3-pyaudio</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pyaudio</exec_depend>
   <exec_depend>python-pyusb-pip</exec_depend>
   <exec_depend>python-speechrecognition-pip</exec_depend>
   <test_depend>jsk_tools</test_depend>

--- a/respeaker_ros/package.xml
+++ b/respeaker_ros/package.xml
@@ -22,7 +22,8 @@
   <exec_depend>python-pixel-ring-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pyaudio</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pyaudio</exec_depend>
-  <exec_depend>python-pyusb-pip</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2" version_lt="1.1.0">python-pyusb-pip</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python-pyusb-pip</exec_depend>
   <exec_depend>python-speechrecognition-pip</exec_depend>
   <test_depend>jsk_tools</test_depend>
 </package>


### PR DESCRIPTION
Includes #247 

pyusb v1.1.0 and upper seems not compatible with Python 2.
See https://github.com/pyusb/pyusb/issues/363 for details.
So this PR adds `version_lt` to `exec_depend` of pyusb when `$ROS_PYTHON_VERSION == 2`.
I know this currently does not affect `rosdep install`, but writing this should be helpful when someone face the same issue.

I'll make this PR ready for review when I confirm my issue is not a special case in https://github.com/pyusb/pyusb/issues/363.