### PR TITLE
Add chatapi ros

### DIFF
--- a/chatapi_ros/CMakeLists.txt
+++ b/chatapi_ros/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(chatapi_ros)
+
+find_package(catkin REQUIRED COMPONENTS
+  )
+
+catkin_package(
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/chatapi_ros/README.md
+++ b/chatapi_ros/README.md
@@ -87,4 +87,4 @@ source devel/setup.bash
 ```
 roslaunch chatapi_ros chatapi.launch
 ```
-You can access the result in rostopics. (`/chatAPI/a3rt` and `/chatAPI/chaplus`)
+You can access the results in rostopics. (`/chatAPI/a3rt` and `/chatAPI/chaplus`)

--- a/chatapi_ros/README.md
+++ b/chatapi_ros/README.md
@@ -1,0 +1,90 @@
+# chatapi_ros
+The purpose of this repository is to make existing chat APIs usable with ROS.
+
+## Setting up environment
+Please install following packages.
+```
+sudo pip install google-api-python-client
+sudo pip install oauth2client
+sudo pip install pya3rt
+```
+
+Please install ros_speech_recognition.
+```
+sudo apt install ros-${ROS_DISTRO}-ros-speech-recognition
+```
+%You can get the latest version from [here](https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/ros_speech_recognition). Please try the latest version if it does not work well.
+
+## Set API Keys for [Chaplus](http://www.chaplus.jp/api) and [A3RT](https://a3rt.recruit-tech.co.jp/product/talkAPI)
+### Get Chaplus APIKey
+Please access [here](http://www.chaplus.jp/api#contact) and enter your information.
+
+### Get A3RT APIKey
+Please access [here](https://a3rt.recruit-tech.co.jp/product/talkAPI/registered/) and enter your information.
+
+### Write your keys in `settings.yaml`
+```
+chaplusAPIKEY: xxxxxxxxxx
+a3rtAPIKEY: yyyyyyyyyy
+```
+
+## Get json file for Google speech recognition API.
+### Get json file
+Please follow the step 1 and 2 in [here](https://cloud.google.com/speech-to-text/docs/quickstart-protocol) and download json file.
+### Place the json file in this repository.
+`chatapi_ros/your-json-name.json`
+
+
+## Rewrite `launch/chatapi.launch` file
+### Change the path of json file.
+```
+<param name="/speech_recognition/google_cloud_credentials_json"
+       value="$(find chatapi_ros)/your-json-name.json" />
+```
+
+### Change the microphone settings.
+Check your microphone.
+```
+pactl list short sinks
+```
+Rewrite the following settings according to your environment. 
+```
+<arg name="n_channel" default="2" />
+<arg name="depth" default="16" />
+<arg name="sample_rate" default="44100" />
+```
+
+Check your card and device number of microphone.
+```
+arecord -l
+```
+Rewrite the following settings to "hw:[card number],[device number]" . 
+```
+<arg name="device" default="hw:0,0" />
+```
+ 
+### Change other settings
+Change the launguage you want to use.
+```
+<arg name="language" default="en" />
+```
+If you do not want to use Chaplus
+```
+<arg name="use_chaplus" default="false" />
+```
+If you do not want to use A3RT
+```
+<arg name="use_a3rt" default="false" />
+```
+
+## Build
+```
+catkin build chatapi_ros
+source devel/setup.bash
+```
+
+## Usage
+```
+roslaunch chatapi_ros chatapi.launch
+```
+You can access the result in rostopics. (`/chatAPI/a3rt` and `/chatAPI/chaplus`)

--- a/chatapi_ros/launch/chatapi.launch
+++ b/chatapi_ros/launch/chatapi.launch
@@ -1,0 +1,58 @@
+<launch>
+
+  <arg name="use_chaplus" default="true" />
+  <arg name="use_a3rt" default="true" />
+
+  <arg name="launch_sound_play" default="false" />
+  <arg name="launch_audio_capture" default="true" />
+  <arg name="audio_topic" default="/audio" />
+  <arg name="n_channel" default="2" />
+  <arg name="depth" default="16" />
+  <arg name="sample_rate" default="44100" />
+  <arg name="device" default="hw:0,0" />
+  <arg name="engine" default="GoogleCloud" />
+  <arg name="language" default="ja-JP" />
+  <arg name="continuous" default="true" />
+
+  <param name="/speech_recognition/google_cloud_credentials_json"
+         value="$(find ros_speech_recognition)/eternal-byte-236613-4bc6962824d1.json" />
+  <param name="/speech_recognition/diarizationConfig"
+         type="yaml"
+         value="{'enableSpeakerDiarization': True, 'maxSpeakerCount': 3}"/>
+
+  <!-- ros_speech_recognition -->
+  <include file="$(find ros_speech_recognition)/launch/speech_recognition.launch" >
+      <arg name="launch_sound_play" default="$(arg launch_sound_play)" />
+      <arg name="launch_audio_capture" default="$(arg launch_audio_capture)" />
+      <arg name="audio_topic" default="$(arg audio_topic)" />
+      <arg name="n_channel" default="$(arg n_channel)" />
+      <arg name="depth" default="$(arg depth)" />
+      <arg name="sample_rate" default="$(arg sample_rate)" />
+      <arg name="device" default="$(arg device)" />
+      <arg name="engine" value="$(arg engine)" />
+      <arg name="language" value="$(arg language)" />
+      <arg name="continuous" value="$(arg continuous)" />
+  </include>
+
+  <!-- use chaplus API -->
+  <node pkg="chatapi_ros"
+        name="talk_chaplus"
+        type="talk_chaplus.py"
+        output="screen"
+        if="$(arg use_chaplus)"
+        respawn="true">
+    <rosparam command="load"
+              file="$(find chatapi_ros)/settings.yaml" />
+  </node>
+
+  <!-- use a3rt API -->
+  <node pkg="chatapi_ros"
+        name="talk_a3rt"
+        type="talk_a3rt.py"
+        output="screen"
+        if="$(arg use_a3rt)"
+        respawn="true">
+    <rosparam command="load"
+              file="$(find chatapi_ros)/settings.yaml" />
+  </node>
+</launch>

--- a/chatapi_ros/package.xml
+++ b/chatapi_ros/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <name>chatapi_ros</name>
+  <version>0.0.0</version>
+  <description>The chatapi_ros package</description>
+
+  <maintainer email="a-fujii@jsk.imi.i.u-tokyo.ac.jp">a-fujii</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>ros_speech_recognition</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/chatapi_ros/scripts/talk_a3rt.py
+++ b/chatapi_ros/scripts/talk_a3rt.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import pya3rt
+import re
+from std_msgs.msg import String
+from speech_recognition_msgs.msg import SpeechRecognitionCandidates
+
+class TalkA3rt(object):
+    def __init__(self):
+        a3rtAPIKEY = rospy.get_param('~a3rtAPIKEY', None)
+        if a3rtAPIKEY is not None:
+            apikey = a3rtAPIKEY
+        else:
+            rospy.logerr('param: chaplus APIKEY is not correctly set.')
+            sys.exit(1)
+
+        self.client = pya3rt.TalkClient(apikey)
+
+        self.talka3rt_pub = rospy.Publisher('chatAPI/a3rt', String, queue_size=1)
+        rospy.Subscriber("/Tablet/voice", SpeechRecognitionCandidates, self.sr_cb)
+
+    def sr_cb(self, msg):
+        result = msg.transcript[0]
+        #Pick out the necessary parts of msg and make a sentence.
+        word = re.findall('\s(.*?)\|', result)
+        words = "".join(word)
+        #In the case of a single word, exclude [num(1, 2, etc.)], and apply as is.
+        if words == "":
+            words=result[4:]
+        print(words)
+
+        speech = self.client.talk(words)
+        try:
+            answer = speech["results"][0]["reply"].encode("utf-8")
+        except:
+            #Add the patterns you want answered as needed.
+            if speech == "おやすみ":
+                answer = "おやすみ"
+            elif speech == "おやすみなさい":
+                answer = "おやすみなさい"
+            else:
+                answer = "ごめんなさい、よくわからないです"
+        print("a3rt: "+answer)
+        self.talka3rt_pub.publish(answer)
+
+if __name__ == '__main__':
+    rospy.init_node('a3rt_publisher')
+    TalkA3rt()
+    rospy.spin()

--- a/chatapi_ros/scripts/talk_chaplus.py
+++ b/chatapi_ros/scripts/talk_chaplus.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+from std_msgs.msg import String
+from speech_recognition_msgs.msg import SpeechRecognitionCandidates
+import requests
+import json
+import re
+
+class TalkChaplus(object):
+
+    def __init__(self):
+        chaplusAPIKEY = rospy.get_param('~chaplusAPIKEY', None)
+        if chaplusAPIKEY is not None:
+            self.url = "https://www.chaplus.jp/v1/chat?apikey=" + chaplusAPIKEY
+        else:
+            rospy.logerr('param: chaplus APIKEY is not correctly set.')
+            sys.exit(1)
+
+        self.talkchaplus_pub = rospy.Publisher('/chatAPI/chaplus', String, queue_size=1)
+        rospy.Subscriber("/Tablet/voice", SpeechRecognitionCandidates, self.topic_cb)
+
+        self.headers = {'content-type':'text/json'}
+
+    def topic_cb(self, msg):
+        result = msg.transcript[0]
+        #Pick out the necessary parts of msg and make a sentence.
+        word = re.findall('\s(.*?)\|', result)
+        words = "".join(word)
+        #In the case of a single word, exclude [num(1, 2, etc.)], and apply as is.
+        if words == "":
+            words=result[4:]
+        print(words)
+
+        #use chaplus
+        payload = {'utterance':words}
+        res = requests.post(url=self.url, headers=self.headers, data=json.dumps(payload))
+        best_res = res.json()['bestResponse']['utterance']
+
+        #publish as rostopic
+        answer = String()
+        answer.data = best_res
+        print("chaplus: "+ best_res)
+        self.talkchaplus_pub.publish(answer)
+
+if __name__ == '__main__':
+    rospy.init_node('chaplus_publisher')
+    TalkChaplus()
+    rospy.spin()

--- a/chatapi_ros/settings.yaml
+++ b/chatapi_ros/settings.yaml
@@ -1,0 +1,2 @@
+chaplusAPIKEY: xxxxxxxxxx
+a3rtAPIKEY: yyyyyyyyyy


### PR DESCRIPTION
The purpose of this repository is to make existing chat APIs usable with ROS.
Chaplus(http://www.chaplus.jp/api) and A3RT(https://a3rt.recruit-tech.co.jp/product/talkAPI) are used.