### PR TITLE
Ignore charactors which AquesTalk2 cannot recognize and update README.md

### DIFF
--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -1,6 +1,9 @@
 # aques_talk
 
-ROS Interface for AqeusTalk2
+ROS Interface for AqeusTalk2.
+
+For detail, Please see [manual](https://www.a-quest.com/archive/manual/aqtk2_lnx_man.pdf) and [symbols table](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)
+
 
 ## Usage
 

--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -41,7 +41,7 @@ client.say('Hello', voice='en')
 
 ### Limitations on input strings
 
-All charactors except `[a-zA-Z0-9ぁ-んー、。?？]` and Kanji are removed so that AquesTalk2 can recognize them.
+All charactors except `[a-zA-Z0-9ぁ-んァ-ンー、。?？]` and Kanji are removed so that AquesTalk2 can recognize them.
 
 ```
 ’こ”^＾ん/に*|ち＊＊｜は；：;:『』！#＃$＄&＆~〜()（）＿_｀\_\\\_・・<\>＊｀＞＜+＋@＠ー=＝%[]-￥
@@ -50,8 +50,10 @@ All charactors except `[a-zA-Z0-9ぁ-んー、。?？]` and Kanji are removed so
 ```
 
 **Do not** input the charactors which are recognized as control charactors. For example,
-- `' "` in many programs (Because many programs recognize them as string control charactor)
-- ``! ` `` if you use shell (Because shell recognizes them as control charactor)
+- `ヰ` `ヱ`
+- `ぁ` (`ぁ` at the beginning of sentence cannot be pronounced, but `ふぁ` can be pronounced.)
+- `'` `"` in many programs (Because many programs recognize them as string control charactor)
+- `!` `` ` `` if you use shell (Because shell recognizes them as control charactor)
 
 You should be careful in input charactors about how they are pronounced.
 ```

--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -51,7 +51,8 @@ All charactors except `[a-zA-Z0-9ぁ-んァ-ンー、。?？]` and Kanji are rem
 
 **Do not** input the unpronounceable or control characters. For example,
 - `ヰ` `ヱ`
-- `ぁ` at the beginning of sentence (`ぁ` at the beginning of sentence cannot be pronounced, but `ふぁ` can be pronounced.)
+- `ぁ` `〜` at the beginning of sentence (`ぁ` or `〜` at the beginning of sentence cannot be pronounced)
+- `たぁ` (On the other hand, `ふぁ` can be pronounced.)
 - `'` `"` in many programs (Because many programs recognize them as string control charactor)
 - `!` `` ` `` if you use shell (Because shell recognizes them as control charactor)
 

--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -49,9 +49,9 @@ All charactors except `[a-zA-Z0-9ぁ-んァ-ンー、。?？]` and Kanji are rem
 こんにちはー
 ```
 
-**Do not** input the charactors which are recognized as control charactors. For example,
+**Do not** input the unpronounceable or control characters. For example,
 - `ヰ` `ヱ`
-- `ぁ` (`ぁ` at the beginning of sentence cannot be pronounced, but `ふぁ` can be pronounced.)
+- `ぁ` at the beginning of sentence (`ぁ` at the beginning of sentence cannot be pronounced, but `ふぁ` can be pronounced.)
 - `'` `"` in many programs (Because many programs recognize them as string control charactor)
 - `!` `` ` `` if you use shell (Because shell recognizes them as control charactor)
 

--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -40,6 +40,21 @@ client.say('Hello', voice='en')
 
 
 ### Limitations on input strings
+
+Some charactors are replaced so that AquesTalk2 can recognize them.
+
+```
+’こ”^＾ん/に*|ち＊＊｜は；：;:『』!！#＃$＄&＆~〜()（）＿_｀\_\\\_・・<\>＊｀＞＜+＋@＠ー=＝
+->
+こんにちはー
+```
+
+
+**Do not** input the following charactors:
+- ``% [ ] ` - ￥`` (Because sed command recognize them as control charactor)
+- `' "` (Because ros publisher (e.g. python or shell) recognized as string control charactor)
+
+You should be careful in input charactors about how they are pronounced.
 ```
 Wrong -> Correct
 20時です -> 20じです # Kanji is sometimes mispronounced.

--- a/3rdparty/aques_talk/README.md
+++ b/3rdparty/aques_talk/README.md
@@ -41,18 +41,17 @@ client.say('Hello', voice='en')
 
 ### Limitations on input strings
 
-Some charactors are replaced so that AquesTalk2 can recognize them.
+All charactors except `[a-zA-Z0-9ぁ-んー、。?？]` and Kanji are removed so that AquesTalk2 can recognize them.
 
 ```
-’こ”^＾ん/に*|ち＊＊｜は；：;:『』!！#＃$＄&＆~〜()（）＿_｀\_\\\_・・<\>＊｀＞＜+＋@＠ー=＝
+’こ”^＾ん/に*|ち＊＊｜は；：;:『』！#＃$＄&＆~〜()（）＿_｀\_\\\_・・<\>＊｀＞＜+＋@＠ー=＝%[]-￥
 ->
 こんにちはー
 ```
 
-
-**Do not** input the following charactors:
-- ``% [ ] ` - ￥`` (Because sed command recognize them as control charactor)
-- `' "` (Because ros publisher (e.g. python or shell) recognized as string control charactor)
+**Do not** input the charactors which are recognized as control charactors. For example,
+- `' "` in many programs (Because many programs recognize them as string control charactor)
+- ``! ` `` if you use shell (Because shell recognizes them as control charactor)
 
 You should be careful in input charactors about how they are pronounced.
 ```

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -38,7 +38,7 @@ if __name__ == '__main__':
                nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
-               sed -e 's/[^a-zA-Z0-9ぁ-んー、。?？]//g' | \
+               sed -e 's/[^a-zA-Z0-9ぁ-んァ-ンー、。?？]//g' | \
                sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -40,17 +40,8 @@ if __name__ == '__main__':
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
                sed -e 's/！/。/g' | sed -e 's/\!/。/g' | \
                sed -e 's/〜/ー/g' | \
-               sed -e 's/ぁ/ー/g' | \
-               sed -e 's/ぃ/ー/g' | \
-               sed -e 's/ぅ/ー/g' | \
-               sed -e 's/ぇ/ー/g' | \
-               sed -e 's/ぉ/ー/g' | \
-               sed -e 's/ァ/ー/g' | \
-               sed -e 's/ィ/ー/g' | \
-               sed -e 's/ゥ/ー/g' | \
-               sed -e 's/ェ/ー/g' | \
-               sed -e 's/ォ/ー/g' | \
                sed -e 's/[^a-zA-Z0-9ぁ-んァ-ンー、。?？]//g' | \
+               sed -e 's/^[ぁぃぅぇぉァィゥェォ、。ー]*//' | \
                sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -32,11 +32,13 @@ if __name__ == '__main__':
 
     # escape invalid code
     # For detail, please see README.md of aques_talk
-    os.system("nkf -j %s | kakasi -JH | nkf -w | \
+    # sed command for Japanese
+    # https://ja.stackoverflow.com/questions/29179/sed-%E3%81%A7-%E3%81%82-%E3%82%9E-%E3%81%AE%E3%82%88%E3%81%86%E3%81%AA%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AE%E6%96%87%E5%AD%97%E7%AF%84%E5%9B%B2%E3%82%92%E4%BD%BF%E3%81%84%E3%81%9F%E3%81%84
+    os.system("unset LC_ALL && unset LC_CTYPE && export LC_COLLATE=C.UTF-8 && \
+               nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
-               sed -e 's/[『』!！#＃$＄&＆~〜()（）;；:：＿_・+＋<>＜＞@＠|｜=＝^＾｀]//g' | \
-               sed -e 's/[\*\＊\’\”\/\\]//g' | \
+               sed -e 's/[^a-zA-Z0-9ぁ-んー、。?？]//g' | \
                sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -31,9 +31,12 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # escape invalid code
+    # For detail, please see README.md of aques_talk
     os.system("nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
+               sed -e 's/[『』!！#＃$＄&＆~〜()（）;；:：＿_・+＋<>＜＞@＠|｜=＝^＾｀]//g' | \
+               sed -e 's/[\*\＊\’\”\/\\]//g' | \
                sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \
                %s"%(input_file, jptext_file))

--- a/3rdparty/aques_talk/text2wave
+++ b/3rdparty/aques_talk/text2wave
@@ -38,6 +38,18 @@ if __name__ == '__main__':
                nkf -j %s | kakasi -JH | nkf -w | \
                sed -e 's/，/、/g' | sed -e 's/,/、/g' | \
                sed -e 's/．/。/g' | sed -e 's/\./。/g' | \
+               sed -e 's/！/。/g' | sed -e 's/\!/。/g' | \
+               sed -e 's/〜/ー/g' | \
+               sed -e 's/ぁ/ー/g' | \
+               sed -e 's/ぃ/ー/g' | \
+               sed -e 's/ぅ/ー/g' | \
+               sed -e 's/ぇ/ー/g' | \
+               sed -e 's/ぉ/ー/g' | \
+               sed -e 's/ァ/ー/g' | \
+               sed -e 's/ィ/ー/g' | \
+               sed -e 's/ゥ/ー/g' | \
+               sed -e 's/ェ/ー/g' | \
+               sed -e 's/ォ/ー/g' | \
                sed -e 's/[^a-zA-Z0-9ぁ-んァ-ンー、。?？]//g' | \
                sed -e 's/\([a-zA-Z]\+\)/<ALPHA VAL=\\1>/g' | \
                sed -e 's/\([0-9]\+\)/<NUMK VAL=\\1>/g' > \


### PR DESCRIPTION
Please see https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/255

With this pull request, for example,
```
’こ”^＾ん/に*|ち＊＊｜は；：;:『』!！#＃$＄&＆~〜()（）＿_｀\_\\\_・・<\>＊｀＞＜+＋@＠ー=＝
```
is converted to
```
こんにちはー
```