### PR TITLE
[slic] fix typo in slic/CMakeLists.txt

### DIFF
--- a/3rdparty/slic/CMakeLists.txt
+++ b/3rdparty/slic/CMakeLists.txt
@@ -19,8 +19,8 @@ ExternalProject_Add(
   )
 
 find_package( OpenCV REQUIRED )
-install(CODE "execute_process(COMMAND cmake -E make_directory ${CMAKE_INSTALL_PREFIX}/incldue/)")
-install(CODE "execute_process(COMMAND cmake -E copy slic.h ${CMAKE_INSTALL_PREFIX}/incldue/ WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/slic-prefix/src/slic/)")
+install(CODE "execute_process(COMMAND cmake -E make_directory ${CMAKE_INSTALL_PREFIX}/include/)")
+install(CODE "execute_process(COMMAND cmake -E copy slic.h ${CMAKE_INSTALL_PREFIX}/include/ WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/slic-prefix/src/slic/)")
 
 install(CODE "execute_process(COMMAND cmake -E make_directory ${CMAKE_INSTALL_PREFIX}/lib/)")
 install(CODE "execute_process(COMMAND gcc -I${OpenCV_INCLUDE_DIRS} -fPIC --shared -o ${CMAKE_INSTALL_PREFIX}/lib/libslic.so ${CMAKE_CURRENT_BINARY_DIR}/slic-prefix/src/slic/slic.cpp)")


### PR DESCRIPTION
`incldue` -> `include`