### PR TITLE
[switchbot_ros] use python setup to avoid relative import in switchbot_ros

### DIFF
--- a/switchbot_ros/CMakeLists.txt
+++ b/switchbot_ros/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(
   actionlib_msgs
 )
 
+catkin_python_setup()
+
 add_action_files(
   FILES
   SwitchBotCommand.action
@@ -16,3 +18,7 @@ generate_messages(
   std_msgs
   actionlib_msgs
 )
+
+catkin_package()
+
+include_directories()

--- a/switchbot_ros/package.xml
+++ b/switchbot_ros/package.xml
@@ -13,7 +13,8 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <exec_depend>python-requests</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
   <exec_depend>message_exectime</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/switchbot_ros/package.xml
+++ b/switchbot_ros/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>switchbot_ros</name>
   <version>2.1.24</version>
   <description>use switchbot with ros</description>
@@ -10,11 +10,13 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <run_depend>python-requests</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
+  <exec_depend>python-requests</exec_depend>
+  <exec_depend>message_exectime</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
   </export>

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -6,7 +6,7 @@ import rospy
 from switchbot_ros.msg import SwitchBotCommandAction
 from switchbot_ros.msg import SwitchBotCommandFeedback
 from switchbot_ros.msg import SwitchBotCommandResult
-from switchbot import SwitchBotAPIClient
+from switchbot_ros.switchbot import SwitchBotAPIClient
 
 
 class SwitchBotAction:

--- a/switchbot_ros/setup.py
+++ b/switchbot_ros/setup.py
@@ -1,0 +1,11 @@
+from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import find_packages
+from setuptools import setup
+
+
+d = generate_distutils_setup(
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+)
+
+setup(**d)

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 import json


### PR DESCRIPTION
I use `catkin_setup_python` to make `switchbot_ros` as python package.
This PR avoids relative import in `switchbot_ros_server.py`, which may causes error in python3.