### PR TITLE
[switchbot_ros] catch the exception when init the node

### DIFF
--- a/switchbot_ros/launch/switchbot.launch
+++ b/switchbot_ros/launch/switchbot.launch
@@ -1,6 +1,9 @@
 <launch>
   <arg name="token" />
-  <node name="switchbot_ros" pkg="switchbot_ros" type="switchbot_ros_server.py" output="screen">
+  <arg name="respawn" default="true" />
+
+  <node name="switchbot_ros" pkg="switchbot_ros" type="switchbot_ros_server.py"
+        respawn="$(arg respawn)" output="screen">
     <rosparam subst_value="true">
       token: $(arg token)
     </rosparam>


### PR DESCRIPTION
Moved from https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/276 .

`SwitchBotAPIClient` class in `switchbot.py` gets the device list from the server when initialized. I forgot catching the network-not-connected exception when it happens so I added it to the rosnode. @knorth55 also added the respawn arg.