### PR TITLE
[lpg_planner] install lpg_planner from jsk-ros-pkg/archieve

### DIFF
--- a/3rdparty/lpg_planner/CMakeLists.txt
+++ b/3rdparty/lpg_planner/CMakeLists.txt
@@ -1,22 +1,23 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(lpg_planner)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED mk)
 catkin_package()
 
-if(EXISTS $ENV{HOME}/Downloads/lpg1.2-linux.tar.gz)
-  add_custom_command(
-    OUTPUT LPG-1.2-linux/lpg-1.2
-    COMMAND tar xvf ~/Downloads/lpg1.2-linux.tar.gz
-    )
-  add_custom_command(
-    OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/lpg-1.2
-    COMMAND cmake -E make_directory ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/
-    COMMAND cmake -E copy LPG-1.2-linux/lpg-1.2 ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/
-    DEPENDS LPG-1.2-linux/lpg-1.2
-    )
-  add_custom_target(build_all ALL DEPENDS ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/lpg-1.2)
-else()
-  message(WARNING "\n\n== Download lpg1.2-linux.tar.gz from http://eracle.ing.unibs.it/lpg/download-lpg1.2.html\nDirect link (http://eracle.ing.unibs.it/lpg/lpg1.2-linux.tar.gz) ==")
-endif()
+add_custom_command(
+  OUTPUT installed
+  COMMAND make -f ${PROJECT_SOURCE_DIR}/Makefile MD5SUM_DIR=${PROJECT_SOURCE_DIR} PATCH_DIR=${PROJECT_SOURCE_DIR}
+)
 
+add_custom_command(
+  OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/lpg-1.2
+  COMMAND cmake -E copy_directory bin/ ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/
+  DEPENDS installed
+)
+
+add_custom_target(lpg ALL
+    DEPENDS ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin/lpg-1.2)
+
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/bin
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)

--- a/3rdparty/lpg_planner/Makefile
+++ b/3rdparty/lpg_planner/Makefile
@@ -1,0 +1,26 @@
+all: installed
+
+INSTALL_DIR=`rospack find lpg_planner`
+FILENAME = lpg1.2-linux.tar.gz
+TARBALL = build/$(FILENAME)
+TARBALL_URL = http://github.com/jsk-ros-pkg/archives/raw/master/$(FILENAME)
+SOURCE_DIR = build/LPG-1.2-linux
+UNPACK_CMD = tar xzf
+MD5SUM_DIR = $(CURDIR)
+MD5SUM_FILE = $(MD5SUM_DIR)/$(FILENAME).md5sum
+include $(shell rospack find mk)/download_unpack_build.mk
+
+installed:$(SOURCE_DIR)/unpacked
+	mkdir -p bin
+	cp $(SOURCE_DIR)/lpg-1.2 bin/
+	touch installed
+
+clean:
+	rm -rf bin
+	rm -rf installed
+
+wiped: Makefile	make wipe
+	touch wiped
+
+wipe: 	clean
+	touch wiped

--- a/3rdparty/lpg_planner/Makefile
+++ b/3rdparty/lpg_planner/Makefile
@@ -1,10 +1,10 @@
 all: installed
 
-INSTALL_DIR=`rospack find lpg_planner`
-FILENAME = lpg1.2-linux.tar.gz
+VERSION = 1.2
+FILENAME = lpg$(VERSION)-linux.tar.gz
 TARBALL = build/$(FILENAME)
 TARBALL_URL = http://github.com/jsk-ros-pkg/archives/raw/master/$(FILENAME)
-SOURCE_DIR = build/LPG-1.2-linux
+SOURCE_DIR = build/LPG-$(VERSION)-linux
 UNPACK_CMD = tar xzf
 MD5SUM_DIR = $(CURDIR)
 MD5SUM_FILE = $(MD5SUM_DIR)/$(FILENAME).md5sum
@@ -12,7 +12,7 @@ include $(shell rospack find mk)/download_unpack_build.mk
 
 installed:$(SOURCE_DIR)/unpacked
 	mkdir -p bin
-	cp $(SOURCE_DIR)/lpg-1.2 bin/
+	cp $(SOURCE_DIR)/lpg-$(VERSION) bin/
 	touch installed
 
 clean:

--- a/3rdparty/lpg_planner/lpg1.2-linux.tar.gz.md5sum
+++ b/3rdparty/lpg_planner/lpg1.2-linux.tar.gz.md5sum
@@ -1,0 +1,1 @@
+f07dc4826e64838d6557fe53450aa615  lpg1.2-linux.tar.gz

--- a/3rdparty/lpg_planner/package.xml
+++ b/3rdparty/lpg_planner/package.xml
@@ -13,5 +13,6 @@
   <author email="h-kamada@jsk.imi.i.u-tokyo.ac.jp">Hitoshi Kamada</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>mk</build_depend>
 
 </package>


### PR DESCRIPTION
we need to manually install `lpg` into `~/Downloads` for current lpg_planner.
this PR change the installation and automatically install `lpg` in `catkin build`.