### PR TITLE
Add verification check rosinfo

### DIFF
--- a/3rdparty/voice_text/launch/voice_text.launch
+++ b/3rdparty/voice_text/launch/voice_text.launch
@@ -9,7 +9,7 @@
 
   <arg name="sound_play_respawn" default="true" />
 
-  <node name="voice_text" pkg="voice_text" type="voice_text"
+  <node name="voice_text" pkg="voice_text" type="voice_text" output="screen"
         machine="$(arg voice_text_machine)">
     <remap from="text_to_speech" to="voice_text/text_to_speech" />
     <rosparam>

--- a/3rdparty/voice_text/src/dummy/vt_dummy.cpp
+++ b/3rdparty/voice_text/src/dummy/vt_dummy.cpp
@@ -10,3 +10,4 @@ int VT_LOADTTS_JPN(int, int, char*, char*) {
 };
 int VT_TextToFile_JPN(int, char *, char *, int, int, int, int, int, int, int) {};
 
+void VT_GetTTSInfo_JPN(int , char *, void *, int) {};

--- a/3rdparty/voice_text/src/dummy/vt_dummy.h
+++ b/3rdparty/voice_text/src/dummy/vt_dummy.h
@@ -4,8 +4,47 @@ extern "C" {
   void VT_UNLOADTTS_JPN(int);
   int VT_LOADTTS_JPN(int, int, char*, char*);
   int VT_TextToFile_JPN(int, char *, char *, int, int, int, int, int, int, int);
+  void VT_GetTTSInfo_JPN(int , char *, void *, int);
   int VT_LOADTTS_SUCCESS = 0;
   int VT_FILE_API_SUCCESS = 0;
   int VT_FILE_API_FMT_S16PCM_WAVE = 4; // https://pastebin.com/9LeCr2HN
 }
+
+enum
+  {
+    VT_BUILD_DATE              =  0,
+    VT_VERIFY_CODE         =  1,
+    VT_MAX_CHANNEL         =  2,
+    VT_DB_DIRECTORY        =  3,
+    VT_LOAD_SUCCESS_CODE   =  4,
+    VT_MAX_SPEAKER         =  5,
+    VT_DEF_SPEAKER         =  6,
+    VT_CODEPAGE            =  7,
+    VT_DB_ACCESS_MODE      =  8,
+    VT_FIXED_POINT_SUPPORT =  9,
+    VT_SAMPLING_FREQUENCY  = 10,
+    VT_MAX_PITCH_RATE      = 11,
+    VT_DEF_PITCH_RATE      = 12,
+    VT_MIN_PITCH_RATE      = 13,
+    VT_MAX_SPEED_RATE      = 14,
+    VT_DEF_SPEED_RATE      = 15,
+    VT_MIN_SPEED_RATE      = 16,
+    VT_MAX_VOLUME          = 17,
+    VT_DEF_VOLUME          = 18,
+    VT_MIN_VOLUME          = 19,
+    VT_MAX_SENT_PAUSE          = 20,
+    VT_DEF_SENT_PAUSE          = 21,
+    VT_MIN_SENT_PAUSE      = 22,
+    VT_DB_BUILD_DATE       = 23,
+    VT_MAX_COMMA_PAUSE         = 24,
+    VT_DEF_COMMA_PAUSE         = 25,
+    VT_MIN_COMMA_PAUSE         = 26,
+    VT_MAX_SYMBOL_OPEN_PAUSE           = 27,
+    VT_DEF_SYMBOL_OPEN_PAUSE           = 28,
+    VT_MIN_SYMBOL_OPEN_PAUSE           = 29,
+    VT_MAX_SYMBOL_CLOSE_PAUSE          = 30,
+    VT_DEF_SYMBOL_CLOSE_PAUSE          = 31,
+    VT_MIN_SYMBOL_CLOSE_PAUSE          = 32,
+  };
+
 #endif //__VT_DUMMY_H__

--- a/3rdparty/voice_text/src/voice_text.cpp.in
+++ b/3rdparty/voice_text/src/voice_text.cpp.in
@@ -24,6 +24,8 @@
 #include "@VT_ROOT@/inc/vt_jpn.h"
 #endif
 
+#define PATH_MAX 1024
+
 namespace fs = boost::filesystem;
 
 
@@ -73,6 +75,27 @@ public:
       return false;
     }
 
+    char szTmp[PATH_MAX];
+    char szTmp2[PATH_MAX];
+    VT_GetTTSInfo_JPN(VT_BUILD_DATE, NULL, szTmp, PATH_MAX);
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_BUILD_DATE = %s\n", szTmp);
+    ROS_INFO_STREAM(szTmp2);
+    VT_GetTTSInfo_JPN(VT_VERIFY_CODE, NULL, &ret, sizeof(int));
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_VERIFY_CODE = %d\n", ret);
+    ROS_INFO_STREAM(szTmp2);
+    VT_GetTTSInfo_JPN(VT_MAX_CHANNEL, NULL, &ret, sizeof(int));
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_MAX_CHANNEL = %d\n", ret);
+    ROS_INFO_STREAM(szTmp2);
+    VT_GetTTSInfo_JPN(VT_DB_DIRECTORY, NULL, szTmp, PATH_MAX);
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_DB_DIRECTORY = %s\n", szTmp);
+    ROS_INFO_STREAM(szTmp2);
+    VT_GetTTSInfo_JPN(VT_DEF_SPEAKER, NULL, &ret, sizeof(int));
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_DEF_SPEAKER = %d\n", ret);
+    ROS_INFO_STREAM(szTmp2);
+    VT_GetTTSInfo_JPN(VT_CODEPAGE, NULL, &ret, sizeof(int));
+    sprintf(szTmp2, "VT_GetTTSInfo_JPN(VT_CODEPAGE = %d\n", ret);
+    ROS_INFO_STREAM(szTmp2);
+
     // advertise service
     srv_ = nh_.advertiseService("text_to_speech", &VoiceText::text_to_speech, this);
 
@@ -110,6 +133,8 @@ public:
                                 config_.volume,
                                 config_.pause,
                                 -1, -1);
+
+    ROS_INFO_STREAM("voice text wave file is outputted to " << wave_char);
 
     free(text_char);
     free(wave_char);


### PR DESCRIPTION
Recently, when I use voice_text in fetch1075, it says "ライセンスが有効ではありません (License not valid)"

I talked with the manufacturer and they advised me that VT_VERIFY_CODE should be set to not 0 when this problem occurs.

So I made VT_VERIFY_CODE to be displayed when voice_text starts.
Also, the path to the wav file generated by voice_text is now displayed.

If fetch1075 says "ライセンスが有効ではありません (License not valid)" again, please give VT_VERIFY_CODE and the generated wav file to the manufacturer.

@mqcmd196 @tkmtnt7000 