### PR TITLE
update jsk_travis 0.5.22

### DIFF
--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:
+          EXTRA_DEB : "python-lxml"
           ROS_DISTRO : indigo
           ROS_PARALLEL_TEST_JOBS: "-j8"
           # latest catkin_virtualenv with pip==21.0.1 is incompatible with python 2.x

--- a/.github/workflows/kinetic-i386.yml
+++ b/.github/workflows/kinetic-i386.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:
+          EXTRA_DEB : "python-lxml"
           ROS_DISTRO : kinetic
           ROS_PARALLEL_TEST_JOBS : "-j8"
           ROSDEP_ADDITIONAL_OPTIONS : "-n -q -r --ignore-src --skip-keys=python-google-cloud-texttospeech-pip --skip-keys=python-dialogflow-pip"  # Skip installation of grpcio by pip because it causes error

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -17,5 +17,6 @@ jobs:
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:
+          EXTRA_DEB : "python-lxml"
           ROS_DISTRO : kinetic
           ROS_PARALLEL_TEST_JOBS: "-j8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - USE_TRAVIS=true
     - USE_DOCKER=true
     - ROS_PARALLEL_TEST_JOBS="-j8"
+    - EXTRA_DEB="python-lxml" # add python-lxml due to https://github.com/ros/rosdistro/pull/31570
     - GIT_SSL_NO_VERIFY=1 # http://stackoverflow.com/questions/21181231/server-certificate-verification-failed-cafile-etc-ssl-certs-ca-certificates-c
   matrix:
     - CHECK_PYTHON2_COMPILE=true


### PR DESCRIPTION
to run `catkin build` instaed of `travis_wait 60 catkin build`
jsk_3rdparty sometime takes more than 60 min for build