### PR TITLE
Enable sound play flag

### DIFF
--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -36,7 +36,7 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
 * `sound_play` (`sound_play/SoundRequestAction`)
 
-  Action client to play sound on events. If the action server is not available or `~enable_sound_play` is `False`, no sound is played.
+  Action client to play sound on events. If the action server is not available or `~enable_sound_effect` is `False`, no sound is played.
   
 ### Subscribing Topics
 
@@ -52,7 +52,7 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
 ## Parameters
 
-* `~enable_sound_play` (`Bool`, default: `True`)
+* `~enable_sound_effect` (`Bool`, default: `True`)
 
     Flag to enable or disable sound to play sound on recognition.
 

--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -36,7 +36,7 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
 * `sound_play` (`sound_play/SoundRequestAction`)
 
-  Action client to play sound on events. If the action server is not available, no sound is played.
+  Action client to play sound on events. If the action server is not available or `~enable_sound_play` is `False`, no sound is played.
   
 ### Subscribing Topics
 
@@ -51,6 +51,10 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
   Service for speech recognition
 
 ## Parameters
+
+* `~enable_sound_play` (`Bool`, default: `True`)
+
+    Flag to enable or disable sound to play sound on recognition.
 
 * `~language` (`String`, default: `en-US`)
 

--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -45,6 +45,7 @@
       engine: $(arg engine)
       language: $(arg language)
       continuous: $(arg continuous)
+      enable_sound_play: $(arg launch_sound_play)
     </rosparam>
   </node>
 </launch>

--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -45,7 +45,7 @@
       engine: $(arg engine)
       language: $(arg language)
       continuous: $(arg continuous)
-      enable_sound_play: $(arg launch_sound_play)
+      enable_sound_effect: $(arg launch_sound_play)
     </rosparam>
   </node>
 </launch>

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -244,9 +244,12 @@ class ROSSpeechRecognition(object):
         try:
             rospy.logdebug("Waiting for result... (Sent %d bytes)" % len(audio.get_raw_data()))
             result = self.recognize(audio)
+            self.play_sound("recognized", 0.05)
             rospy.loginfo("Result: %s" % result.encode('utf-8'))
+            self.play_sound("success", 0.1)
             msg = SpeechRecognitionCandidates(transcript=[result])
             self.pub.publish(msg)
+            return
         except SR.UnknownValueError as e:
             if self.dynamic_energy_threshold:
                 self.recognizer.adjust_for_ambient_noise(self.audio)
@@ -257,6 +260,7 @@ class ROSSpeechRecognition(object):
             rospy.logerr("Failed to recognize: %s" % str(e))
         except:
             rospy.logerr("Unexpected error: %s" % str(sys.exc_info()))
+        self.play_sound("timeout", 0.1)
 
     def start_speech_recognition(self):
         if self.dynamic_energy_threshold:
@@ -264,6 +268,7 @@ class ROSSpeechRecognition(object):
                 self.recognizer.adjust_for_ambient_noise(src)
                 rospy.loginfo("Set minimum energy threshold to {}".format(
                     self.recognizer.energy_threshold))
+        self.play_sound("start", 0.1)
         self.stop_fn = self.recognizer.listen_in_background(
             self.audio, self.audio_cb, phrase_time_limit=self.phrase_time_limit)
         rospy.on_shutdown(self.on_shutdown)

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -121,9 +121,14 @@ class ROSSpeechRecognition(object):
                               buffer_size=rospy.get_param("~buffer_size", 10240))
 
         # initialize sound play client
-        self.act_sound = actionlib.SimpleActionClient("sound_play", SoundRequestAction)
-        if not self.act_sound.wait_for_server(rospy.Duration(5.0)):
-            rospy.logwarn("Failed to find sound_play action. Disabled audio alert")
+        if rospy.get_param('~enable_sound_play', True):
+            self.act_sound = actionlib.SimpleActionClient(
+                "sound_play", SoundRequestAction)
+            if not self.act_sound.wait_for_server(rospy.Duration(5.0)):
+                rospy.logwarn("Failed to find sound_play action. "
+                              "Disabled audio alert")
+                self.act_sound = None
+        else:
             self.act_sound = None
         self.signals = {
             "start": rospy.get_param("~start_signal",

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -121,12 +121,12 @@ class ROSSpeechRecognition(object):
                               buffer_size=rospy.get_param("~buffer_size", 10240))
 
         # initialize sound play client
-        if rospy.get_param('~enable_sound_play', True):
+        if rospy.get_param('~enable_sound_effect', True):
             self.act_sound = actionlib.SimpleActionClient(
                 "sound_play", SoundRequestAction)
             if not self.act_sound.wait_for_server(rospy.Duration(5.0)):
                 rospy.logwarn("Failed to find sound_play action. "
-                              "Disabled audio alert")
+                              "Disabled sound effect on recognition.")
                 self.act_sound = None
         else:
             self.act_sound = None

--- a/ros_speech_recognition/test/sample_ros_speech_recognition.test
+++ b/ros_speech_recognition/test/sample_ros_speech_recognition.test
@@ -1,12 +1,14 @@
 <launch>
   <!-- launch speech recognition -->
+
+  <arg name="launch_sound_play" default="false" doc="Launch sound_play node to speak" />
   <rosparam>
     <!-- We use rosbag which contains /speech_audio, which many /audio topics stuck together -->
     <!-- Therefore, we need long buffer size for this test -->
     /speech_recognition/buffer_size: 200000
   </rosparam>
   <include file="$(find ros_speech_recognition)/launch/speech_recognition.launch">
-    <arg name="launch_sound_play" value="false" />
+    <arg name="launch_sound_play" value="$(arg launch_sound_play)" />
     <arg name="launch_audio_capture" value="false" />
     <arg name="audio_topic" value="/speech_audio" />
     <arg name="language" value="ja" />


### PR DESCRIPTION
# What is this?

Add a flag to enable or disable sound to play sound on recognition and add `play_sound` for continuous recognition mode.

You can select mute or unmute sound effects on speech recognition.

## Quick start

Using test rosbag, you can try this PR.

```
roslaunch ros_speech_recognition sample_ros_speech_recognition.test launch_sound_play:=true
```