### PR TITLE
[dialogflow_task_executive] load dialogflow project_id from credentials

### DIFF
--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -3,13 +3,13 @@
 
 import actionlib
 import dialogflow as df
+from google.oauth2.service_account import Credentials
 from google.protobuf.json_format import MessageToJson
 import pprint
 import Queue
 import rospy
 import threading
 import uuid
-import os
 
 from audio_common_msgs.msg import AudioData
 from sound_play.msg import SoundRequest
@@ -62,8 +62,6 @@ class State(object):
 class DialogflowClient(object):
 
     def __init__(self):
-        # project id for google cloud service
-        self.project_id = rospy.get_param("~project_id")
         # language for dialogflow
         self.language = rospy.get_param("~language", "ja-JP")
 
@@ -71,10 +69,6 @@ class DialogflowClient(object):
         self.use_audio = rospy.get_param("~use_audio", False)
         # sample rate of audio data
         self.audio_sample_rate = rospy.get_param("~audio_sample_rate", 16000)
-
-        # if GOOLGE_APPLICATION_CREDENTIALS is not set, use google_cloud_credentials_json param
-        if not "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = rospy.get_param("~google_cloud_credentials_json")
 
         # use TTS feature
         self.use_tts = rospy.get_param("~use_tts", True)
@@ -89,9 +83,26 @@ class DialogflowClient(object):
 
         self.state = State()
         self.session_id = None
-        self.session_client = df.SessionsClient()
         self.queue = Queue.Queue()
-        self.last_spoken = rospy.Time(0)
+
+        credentials_json = rospy.get_param(
+            '~google_cloud_credentials_json', None)
+        if credentials_json is None:
+            rospy.loginfo("Loading credential json from env")
+            # project id for google cloud service
+            self.project_id = rospy.get_param("~project_id", None)
+            self.session_client = df.SessionsClient()
+        else:
+            rospy.loginfo("Loading credential json from rosparam")
+            credentials = Credentials.from_service_account_file(
+                credentials_json
+            )
+            self.project_id = credentials.project_id
+            self.session_client = df.SessionsClient(
+                credentials=credentials
+            )
+        if self.project_id is None:
+            rospy.logerr('project ID is not set')
 
         if self.use_tts:
             soundplay_action_name = rospy.get_param(


### PR DESCRIPTION
this PR is split from #313 
this PR loads `project_id` from `credential` json.
with this PR, we only need to pass json path, no need to pass project id.
