### PR TITLE
[switchbot_ros] remove catching base exception and output more specific key error when the switchbot id not exists on the server

### DIFF
--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -8,6 +8,7 @@ from switchbot_ros.msg import SwitchBotCommandAction
 from switchbot_ros.msg import SwitchBotCommandFeedback
 from switchbot_ros.msg import SwitchBotCommandResult
 from switchbot_ros.switchbot import SwitchBotAPIClient
+from switchbot_ros.switchbot import DeviceError, SwitchBotAPIError
 
 
 class SwitchBotAction:
@@ -40,7 +41,7 @@ class SwitchBotAction:
             execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
 
-        
+
     def execute_cb(self, goal):
         feedback = SwitchBotCommandFeedback()
         result = SwitchBotCommandResult()
@@ -62,7 +63,7 @@ class SwitchBotAction:
                     command_type=command_type,
                     device_name=goal.device_name
                 ))
-        except Exception as e:
+        except (DeviceError, SwitchBotAPIError, KeyError) as e:
             rospy.logerr(str(e))
             feedback.status = str(e)
             success = False

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -111,7 +111,10 @@ class SwitchBotAPIClient(object):
         if device_id:
             pass
         elif device_name:
-            device_id = self.device_name_id[device_name]
+            try:
+                device_id = self.device_name_id[device_name]
+            except KeyError as e:
+                raise KeyError("Device name:{} is not registered at switchbot server. Please check the setting.".format(device_name))
         else:
             raise ValueError("Please set device_id or device_name.")
 
@@ -130,7 +133,10 @@ class SwitchBotAPIClient(object):
         if device_id:
             pass
         elif device_name:
-            device_id = self.device_name_id[device_name]
+            try:
+                device_id = self.device_name_id[device_name]
+            except KeyError as e:
+                raise KeyError("Device name:{} is not registered at switchbot server. Please check the setting.".format(device_name))
         else:
             raise ValueError("Please set device_id or device_name.")
         
@@ -144,7 +150,10 @@ class SwitchBotAPIClient(object):
         if scene_id:
             pass
         elif scene_name:
-            scene_id = self.scene_name_id[scene_name]
+            try:
+                scene_id = self.scene_name_id[scene_name]
+            except KeyError as e:
+                raise KeyError("Scene name:{} is not registered at switchbot server. Please check the setting.".format(scene_name))
         else:
             raise ValueError("Please set scene_id or scene_name.")
 


### PR DESCRIPTION
When publish the switchbot control action topic with switchbot device which not exists 
before this PR
```
[ERROR] [WallTime: 1642402768.977277] [node:/switchbot_ros] [func:SwitchBotAction.execute_cb]: '/eng2/7f/73b2/light/upper/switch'
```
after this PR
```
[ERROR] [WallTime: 1642405853.687783] [node:/switchbot_ros] [func:SwitchBotAction.execute_cb]: 'Device name:/eng2/7f/73b2/light/upper/switch is not registered at switchbot server. Please check the setting.'
```
and also returns the action feedback status.   
In addition I removed catching base exception part. cc:@708yamaguchi @tkmtnt7000 