### PR TITLE
fix protobuf version 3.14.0, add import test

### DIFF
--- a/dialogflow_task_executive/CMakeLists.txt
+++ b/dialogflow_task_executive/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
     message_generation
     std_msgs
     catkin_virtualenv
+    rostest
 )
 
 add_message_files(
@@ -45,6 +46,18 @@ catkin_package(
 catkin_generate_virtualenv(INPUT_REQUIREMENTS requirements.in)
 
 file(GLOB NODE_SCRIPTS_FILES node_scripts/*.py)
+file(GLOB TEST_SCRIPTS_FILES test/*.py)
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_install_python(
+    PROGRAMS ${TEST_SCRIPTS_FILES}
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+  add_rostest(test/google_import.test
+    DEPENDENCIES ${PROJECT_NAME}_generate_virtualenv
+  )
+endif()
+
 catkin_install_python(
   PROGRAMS ${NODE_SCRIPTS_FILES}
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/dialogflow_task_executive/requirements.in
+++ b/dialogflow_task_executive/requirements.in
@@ -1,2 +1,2 @@
 dialogflow==1.1.1
-
+protobuf==3.14.0

--- a/dialogflow_task_executive/test/google_import.test
+++ b/dialogflow_task_executive/test/google_import.test
@@ -1,0 +1,5 @@
+<launch>
+  <test test-name="test_import"
+        pkg="dialogflow_task_executive"
+        type="test_import.py" />
+</launch>

--- a/dialogflow_task_executive/test/test_import.py
+++ b/dialogflow_task_executive/test/test_import.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import unittest
+
+PKG = 'dialogflow_task_executive'
+NAME = 'test_import'
+
+class TestBlock(unittest.TestCase):
+    def __init__(self, *args):
+        super(TestBlock, self).__init__(*args)
+
+    def test_import(self):
+        try:
+            import dialogflow as df
+            from google.oauth2.service_account import Credentials
+            from google.protobuf.json_format import MessageToJson
+        except Exception as e:
+            assert False
+
+if __name__ == "__main__":
+    import rostest
+    rostest.rosrun(PKG, NAME, TestBlock)


### PR DESCRIPTION
When installing protobuf, 3.18.0 is installed now, however it drops the support of python2.7 and caused a lot of problems.
In Fetch1075,
`pip show protobuf`
```
fetch@fetch1075:~$ pip show protobuf
Name: protobuf
Version: 3.18.0
Summary: Protocol Buffers
Home-page: https://developers.google.com/protocol-buffers/
Author: None
Author-email: None
License: 3-Clause BSD License
Location: /usr/local/lib/python2.7/dist-packages
Requires:
```
IPython
```
In [1]: import dialogflow as df
  File "/usr/local/lib/python2.7/dist-packages/google/protobuf/descriptor.py", line 113
    class DescriptorBase(metaclass=DescriptorMetaclass):
                                  ^
SyntaxError: invalid syntax
```
In Spot
https://docs.google.com/presentation/d/1Vn-I4_POsNnZGAB788kvTtJMbqsBhwSqTs-fMq9WH68/edit#slide=id.p (JSK MEMBER ONLY)

So I fixed the version of protobuf==3.14.0.
```
fetch@fetch1075:~$ pip show protobuf
Name: protobuf
Version: 3.14.0
Summary: Protocol Buffers
Home-page: https://developers.google.com/protocol-buffers/
Author: None
Author-email: None
License: 3-Clause BSD License
Location: /usr/local/lib/python2.7/dist-packages
Requires: six
```
, no error with `import dialogflow as df`