### PR TITLE
[dialogflow_task_executive] Fix bugs when subscribing /text (std_msgs/String) topic

### DIFF
--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -154,6 +154,10 @@ class DialogflowClient(object):
             rospy.loginfo("Hotword received")
             self.state.set(State.LISTENING)
 
+    def text_cb(self, msg):
+        self.queue.put(msg)
+        rospy.loginfo("Recieved input")
+
     def input_cb(self, msg):
         if not self.enable_hotword:
             self.state.set(State.LISTENING)
@@ -161,8 +165,9 @@ class DialogflowClient(object):
             # catch hotword from string
             if isinstance(msg, SpeechRecognitionCandidates):
                 self.hotword_cb(String(data=msg.transcript[0]))
+            # if std_msgs/String was subscribed
             elif isinstance(msg, String):
-                self.hotword_cb(data)
+                self.text_cb(msg)
             else:
                 rospy.logerr("Unsupported data class {}".format(msg))
 


### PR DESCRIPTION
Original code raises the error because https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/712cf105484c334a8f6e680176b72b76c7bc0f33/dialogflow_task_executive/node_scripts/dialogflow_client.py#L165 . `data` is not defined.