### PR TITLE
fix jsk_travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".travis"]
 	path = .travis
-	url = git://github.com/jsk-ros-pkg/jsk_travis
+	url = https://github.com/jsk-ros-pkg/jsk_travis


### PR DESCRIPTION
Test fails following error
```
Submodule '.travis' (git://github.com/jsk-ros-pkg/jsk_travis) registered for path '.travis'
Cloning into '/__w/jsk_3rdparty/jsk_3rdparty/.travis'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/__w/jsk_3rdparty/jsk_3rdparty/.travis' failed
Failed to clone '.travis'. Retry scheduled
Cloning into '/__w/jsk_3rdparty/jsk_3rdparty/.travis'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/__w/jsk_3rdparty/jsk_3rdparty/.travis' failed
Failed to clone '.travis' a second time, aborting
Error: Process completed with exit code 1.
```
and it might be caused by github's dropping support of git:// protocol. https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git