### PR TITLE
dialogflow_task_executive: more depends and udpate README.md

### DIFF
--- a/dialogflow_task_executive/README.md
+++ b/dialogflow_task_executive/README.md
@@ -33,7 +33,9 @@ You can download the key as JSON file in the age and save the JSON file in your 
 
 ![](./img/service_account_key.png)
 
-### Set environmental variables in your robot
+### Set configuration
+
+#### Use environmental variables
 
 We need to set two environment variables: `GOOGLE_APPLICATION_CREDENTIALS` and `DIALOGFLOW_PROJECT_ID`.
 
@@ -41,6 +43,14 @@ We need to set two environment variables: `GOOGLE_APPLICATION_CREDENTIALS` and `
   - Path to Service account key JSON file (i.e. `/etc/ros/hogehoge.json`)
 - `DIALOGFLOW_PROJECT_ID`
   - Dialogflow project ID (i.e. `pr2-hogehoge`)
+
+#### Use launch file arguments
+
+Or we can use `credential` and `project_id` arguments of ` dialogflow_task_executive.launch` file
+
+```
+roslaunch dialogflow_task_executive dialogflow_task_executive.launch credential:=/etc/ros/hogehoge.json project_id:=pr2-hogehoge
+```
 
 ## How to register new task in Dialogflow
 

--- a/dialogflow_task_executive/package.xml
+++ b/dialogflow_task_executive/package.xml
@@ -18,7 +18,8 @@
   <build_depend>std_msgs</build_depend>
   <run_depend>app_manager</run_depend>
   <run_depend>message_runtime</run_depend>
-  <run_depend>python-dialogflow-pip</run_depend>
+  <run_depend>speech_recognition_msgs</run_depend>
+  <!-- <run_depend>python-dialogflow-pip</run_depend> install via catkin_virtualenv -->
 
   <export>
     <pip_requirements>requirements.txt</pip_requirements>


### PR DESCRIPTION
- add comment on how to use roslaunch argument

- dialogflow_task_executive: add speech_recognition_msgs, which is used in  node_scripts/dialogflow_client.py