### PR TITLE
[dialogflow_task_executive] add actionlib method to send request to dialogflow

### DIFF
--- a/dialogflow_task_executive/CMakeLists.txt
+++ b/dialogflow_task_executive/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 find_package(catkin REQUIRED COMPONENTS
     message_generation
     std_msgs
+    actionlib_msgs
     catkin_virtualenv
 )
 
@@ -33,9 +34,15 @@ add_message_files(
   DialogResponse.msg
 )
 
+add_action_files(
+  FILES
+  Text.action
+)
+
 generate_messages(
   DEPENDENCIES
   std_msgs
+  actionlib_msgs
 )
 
 catkin_package(

--- a/dialogflow_task_executive/action/Text.action
+++ b/dialogflow_task_executive/action/Text.action
@@ -7,6 +7,6 @@ string session
 bool done
 ---
 # Define a feedback message
-string queue_added
+bool queue_added
 string session
 string status

--- a/dialogflow_task_executive/action/Text.action
+++ b/dialogflow_task_executive/action/Text.action
@@ -1,0 +1,12 @@
+# Define the goal
+string query
+---
+# Define the result
+DialogResponse response
+string session
+bool done
+---
+# Define a feedback message
+string queue_added
+string session
+string status

--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -298,10 +298,9 @@ class DialogflowClient(object):
                     result = self.detect_intent_text(
                         msg.data, session)
                 elif isinstance(msg, TextGoal):
-                    if not self.action_flag:
-                        result = self.detect_intent_text(
+                    if not self.action_df_result:
+                        self.action_df_result = self.detect_intent_text(
                             msg.query, session)
-                        self.action_df_result = result
                         self.action_session = session
                     else:
                         pass

--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -209,7 +209,7 @@ class DialogflowClient(object):
     def print_result(self, result):
         rospy.loginfo(pprint.pformat(result))
 
-    def publish_result(self, result):
+    def _build_dialogflow_msg(self, result):
         msg = DialogResponse()
         msg.header.stamp = rospy.Time.now()
         if result.action != 'input.unknown':
@@ -226,6 +226,9 @@ class DialogflowClient(object):
         msg.parameters = MessageToJson(result.parameters)
         msg.speech_score = result.speech_recognition_confidence
         msg.intent_score = result.intent_detection_confidence
+
+    def publish_result(self, result):
+        msg = self._build_dialogflow_msg(result)
         self.pub_res.publish(msg)
 
     def speak_result(self, result):
@@ -278,7 +281,7 @@ class DialogflowClient(object):
                     try:
                         result = self.detect_intent_text(
                             msg.query, session)
-                        as_result.response = result
+                        as_result.response = self._build_dialogflow_msg(result)
                         as_result.session = session
                     except Exception as e:
                         as_feedback.status = str(e)

--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -250,6 +250,7 @@ class DialogflowClient(object):
         msg.parameters = MessageToJson(result.parameters)
         msg.speech_score = result.speech_recognition_confidence
         msg.intent_score = result.intent_detection_confidence
+        return msg
 
     def publish_result(self, result):
         msg = self._build_dialogflow_msg(result)
@@ -299,8 +300,9 @@ class DialogflowClient(object):
                         msg.data, session)
                 elif isinstance(msg, TextGoal):
                     if not self.action_df_result:
-                        self.action_df_result = self.detect_intent_text(
+                        result = self.detect_intent_text(
                             msg.query, session)
+                        self.action_df_result = result
                         self.action_session = session
                     else:
                         pass


### PR DESCRIPTION
This PR enables to use `dialogflow_task_executive` with `actionlib`. `dialogflow_task_executive` just subscribes text, audio ROS topic and publishes the ROS topic of the response from dialogflow server, but it is inconvenient if there are multi clients and many requests. If it supports actionlib, the client node can get correct result from it. 