### PR TITLE
Pr/add switchbot device list publisher

### DIFF
--- a/switchbot_ros/CMakeLists.txt
+++ b/switchbot_ros/CMakeLists.txt
@@ -3,6 +3,7 @@ project(switchbot_ros)
 
 find_package(
   catkin REQUIRED COMPONENTS
+  message_generation
   actionlib_msgs
 )
 

--- a/switchbot_ros/CMakeLists.txt
+++ b/switchbot_ros/CMakeLists.txt
@@ -8,6 +8,12 @@ find_package(
 
 catkin_python_setup()
 
+add_message_files(
+  FILES
+  Device.msg
+  DeviceArray.msg
+)
+
 add_action_files(
   FILES
   SwitchBotCommand.action

--- a/switchbot_ros/msg/Device.msg
+++ b/switchbot_ros/msg/Device.msg
@@ -1,0 +1,2 @@
+string name
+string type

--- a/switchbot_ros/msg/DeviceArray.msg
+++ b/switchbot_ros/msg/DeviceArray.msg
@@ -1,0 +1,1 @@
+switchbot_ros/Device[] devices

--- a/switchbot_ros/package.xml
+++ b/switchbot_ros/package.xml
@@ -13,8 +13,11 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
+  <build_depend>message_generation</build_depend>
+
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
+  <exec_depend>actionlib</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -35,7 +35,7 @@ class SwitchBotAction:
             execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
         # Topic
-        self.pub = rospy.Publisher('~devices', DeviceArray, queue_size=1, latched=True)
+        self.pub = rospy.Publisher('~devices', DeviceArray, queue_size=1, latch=True)
         self.published = False
 
     def get_switchbot_client(self):

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -40,7 +40,9 @@ class SwitchBotAction:
 
     def get_switchbot_client(self):
         try:
-            return SwitchBotAPIClient(token=self.token)
+            client = SwitchBotAPIClient(token=self.token)
+            rospy.loginfo('Switchbot API Client initialized.')
+            return client
         except ConnectionError:  # If the machine is not connected to the internet
             rospy.logwarn_once('Failed to connect to the switchbot server. The client would try connecting to it when subscribes the ActionGoal topic.')
             return None

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -7,6 +7,8 @@ import rospy
 from switchbot_ros.msg import SwitchBotCommandAction
 from switchbot_ros.msg import SwitchBotCommandFeedback
 from switchbot_ros.msg import SwitchBotCommandResult
+from switchbot_ros.msg import Device
+from switchbot_ros.msg import DeviceArray
 from switchbot_ros.switchbot import SwitchBotAPIClient
 from switchbot_ros.switchbot import DeviceError, SwitchBotAPIError
 
@@ -24,32 +26,69 @@ class SwitchBotAction:
                 self.token = f.read().replace('\n', '')
         else:
             self.token = token
-        try:
-            self.bots = SwitchBotAPIClient(token=self.token)
-            device_list_str = 'Switchbot device list:\n'
-            device_list = sorted(
-                self.bots.device_list,
-                key=lambda device: str(device['deviceName']))
-            for device in device_list:
-                device_list_str += 'Name: ' + str(device['deviceName'])
-                device_list_str += ', Type: ' + str(device['deviceType'])
-                device_list_str += '\n'
-            rospy.loginfo(device_list_str)
-        except ConnectionError as e: # If the machine is not connected to the internet
-            self.bots = None
-            rospy.logwarn('Failed to connect to the switchbot server. The client would try connecting to it when subscribes the ActionGoal topic.')
+        # Initialize switchbot client
+        self.bots = self.get_switchbot_client()
+        self.print_devices()
         # Actionlib
         self._as = actionlib.SimpleActionServer(
             '~switch', SwitchBotCommandAction,
             execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
+        # Topic
+        self.pub = rospy.Publisher('~devices', DeviceArray, queue_size=1)
 
+    def get_switchbot_client(self):
+
+        try:
+            return SwitchBotAPIClient(token=self.token)
+        except ConnectionError:  # If the machine is not connected to the internet
+            rospy.logwarn('Failed to connect to the switchbot server. The client would try connecting to it when subscribes the ActionGoal topic.')
+            return None
+
+    def spin(self):
+
+        rate = rospy.Rate(1)
+        while not rospy.is_shutdown():
+            rate.sleep()
+            if self.bots is None:
+                self.bots = self.get_switchbot_client()
+            else:
+                self.publish_devices()
+
+    def print_devices(self):
+
+        if self.bots is None:
+            return
+        device_list_str = 'Switchbot device list:\n'
+        device_list = sorted(
+            self.bots.device_list,
+            key=lambda device: str(device['deviceName']))
+        for device in device_list:
+            device_list_str += 'Name: ' + str(device['deviceName'])
+            device_list_str += ', Type: ' + str(device['deviceType'])
+            device_list_str += '\n'
+        rospy.loginfo(device_list_str)
+
+    def publish_devices(self):
+
+        if self.bots is None:
+            return
+        msg = DeviceArray()
+        device_list = sorted(
+            self.bots.device_list,
+            key=lambda device: str(device['deviceName']))
+        for device in device_list:
+            msg_device = Device()
+            msg_device.name = str(device['deviceName'])
+            msg_device.type = str(device['deviceType'])
+            msg.devices.append(msg_device)
+        self.pub.publish(msg)
 
     def execute_cb(self, goal):
         feedback = SwitchBotCommandFeedback()
         result = SwitchBotCommandResult()
         r = rospy.Rate(1)
-        success = True        
+        success = True
         # start executing the action
         parameter, command_type = goal.parameter, goal.command_type
         if not parameter:
@@ -80,4 +119,4 @@ class SwitchBotAction:
 if __name__ == '__main__':
     rospy.init_node('switchbot')
     server = SwitchBotAction()
-    rospy.spin()
+    server.spin()


### PR DESCRIPTION
This PR add an device list interface to [switchbot_ros](https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/switchbot_ros).

```bash
~/ros/ws_jsk_fetch/src/jsk-ros-pkg/jsk_3rdparty/switchbot_ros $ rostopic echo /switchbot_ros/devices
devices:       
  -
    name: "/eng2/2f/elevator/up/button"
    type: "Bot"     
  -
    name: "/eng2/3f/elevator/up/button"
    type: "Bot"
  -
    name: "/eng2/3f/elevatorhall"
    type: "Hub Mini"
  -
    name: "/eng2/3f/new/autodoor/switch"
    type: "Bot"     
  -
    name: "/eng2/3f/old/autodoor/switch"
    type: "Bot"   
  -
    name: "/eng2/7f/73b2/bot6/button"
    type: "Bot"
  -                                    
    name: "/eng2/7f/73b2/light/lower/switch"
    type: "Bot"
  -                                    
    name: "/eng2/7f/73b2/light/upper/switch"
    type: "Bot"
  -                              
    name: "/eng2/7f/73b2/test/button"
    type: "Bot"
  -                                     
    name: "/eng2/7f/elevator/down/button"
    type: "Bot"
  -                                     
    name: "/eng2/7f/elevatorhall"
    type: "Hub Mini"
  -                                  
    name: "JSK_202012_Bot_5"
    type: "Bot"
  -                                         
    name: "JSK_202012_HubMini_2"
    type: "Hub Mini"
  -                                         
    name: "JSK_202012_HubMini_4"
    type: "Hub Mini"
  -                                  
    name: "Remote"
    type: "Remote"
---                       
```