### PR TITLE
[respeaker_ros] Add documentation for displaying Japanese `/speech_to_text`

### DIFF
--- a/respeaker_ros/README.md
+++ b/respeaker_ros/README.md
@@ -72,7 +72,6 @@ A ROS Package for Respeaker Mic Array
     rostopic echo /speech_to_text      # Voice recognition
     # Voice recognition result for Japanese
     rostopic echo --filter "print(m.transcript[0])" /speech_to_text
-    rostopic echo --filter "print('transcript: [%s]\n---'%(', '.join(map(lambda x: '\'%s\''%(x.decode('utf-8')), m.transcript))))" /speech_to_text
     rostopic echo /speech_to_text | ascii2uni -a U -q
     ```
 

--- a/respeaker_ros/README.md
+++ b/respeaker_ros/README.md
@@ -69,6 +69,11 @@ A ROS Package for Respeaker Mic Array
     rostopic echo /is_speeching        # Result of VAD
     rostopic echo /audio               # Raw audio
     rostopic echo /speech_audio        # Audio data while speeching
+    rostopic echo /speech_to_text      # Voice recognition
+    # Voice recognition result for Japanese
+    rostopic echo --filter "print(m.transcript[0])" /speech_to_text
+    rostopic echo --filter "print('transcript: [%s]\n---'%(', '.join(map(lambda x: '\'%s\''%(x.decode('utf-8')), m.transcript))))" /speech_to_text
+    rostopic echo /speech_to_text | ascii2uni -a U -q
     ```
 
     You can also set various parameters via `dynamic_reconfigure`.

--- a/respeaker_ros/README.md
+++ b/respeaker_ros/README.md
@@ -72,6 +72,7 @@ A ROS Package for Respeaker Mic Array
     rostopic echo /speech_to_text      # Voice recognition
     # Voice recognition result for Japanese
     rostopic echo --filter "print(m.transcript[0])" /speech_to_text
+    rostopic echo --filter "print('transcript: [%s]\n---'%(', '.join(map(str, m.transcript))))" /speech_to_text
     rostopic echo /speech_to_text | ascii2uni -a U -q
     ```
 


### PR DESCRIPTION
This PR adds documentation for getting readable Japanese voice recognition results from `rostopic echo`.
Users sometimes had a problem that they don't know making Japanese voice recognition results readable through `rostopic echo` and where the example code is.

### Examples
```
$ rostopic echo --filter "print(m.transcript[0])" /speech_to_text
こんにちは
```
c.f. https://github.com/jsk-ros-pkg/jsk_demos/issues/1347#issuecomment-965031001, https://github.com/jsk-ros-pkg/jsk_demos/issues/1347#issuecomment-965044286
```
k-okada@p51s:~$ rostopic echo /text
data: !!python/str "\u3053\u3093\u306B\u3061\u306F 1636542913.42"
---
data: !!python/str "\u3053\u3093\u306B\u3061\u306F 1636542913.52"
^Ck-okada@p51s:~$ rostopic echo /text | ascii2uni -a U -q
data: !!python/str "こんにちは 1636542916.02"
```
```
rostopic echo --filter "print('transcript: [%s]\n---'%(', '.join(map(lambda x: '\'%s\''%(x.decode('utf-8')), m.transcript))))" /speech_to_text
transcript: [' こんにちは 。', ' こんにちは あ 。', ' 今日 わ 。', ' こんにちは は 。', ' 今日 は 。']
```