### PR TITLE
fix type on dialogflow_task_executive/requirements.txt.indigo

### DIFF
--- a/dialogflow_task_executive/requirements.txt.indigo
+++ b/dialogflow_task_executive/requirements.txt.indigo
@@ -1,5 +1,5 @@
 ####
-#### this is only sed for indigo (pr2)
+#### this is only used for indigo (pr2)
 ####
 #### kinetic+ users will use requirements.in
 ####


### PR DESCRIPTION
`#### this is only sed for indigo (pr2)` -> `#### this is only used for indigo (pr2)`