### PR TITLE
[switchbot_ros] add actionlib_msgs and std_msgs as build_depend

### DIFF
--- a/switchbot_ros/CMakeLists.txt
+++ b/switchbot_ros/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(
   catkin REQUIRED COMPONENTS
   message_generation
   actionlib_msgs
+  std_msgs
 )
 
 catkin_python_setup()
@@ -16,14 +17,14 @@ add_message_files(
 )
 
 add_action_files(
-  FILES
-  SwitchBotCommand.action
+  DIRECTORY action
+  FILES SwitchBotCommand.action
 )
 
 generate_messages(
   DEPENDENCIES
-  std_msgs
   actionlib_msgs
+  std_msgs
 )
 
 catkin_package()

--- a/switchbot_ros/package.xml
+++ b/switchbot_ros/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
+  <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -20,8 +21,10 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
   <exec_depend>actionlib</exec_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
   </export>

--- a/switchbot_ros/package.xml
+++ b/switchbot_ros/package.xml
@@ -13,14 +13,15 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
+  <build_depend>actionlib_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
   <exec_depend>actionlib</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
this PR solve #356 
add `actionlib_msgs` and `std_msgs` as `build_depend`.
these packages are used in `CMakeLists.txt`.

https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/f0ab7bba54523b8f9945ed4a3e9c0efec0c8dde9/switchbot_ros/CMakeLists.txt#L23-L27