### PR TITLE
[dialogflow_task_executive] adding some args in dialogflow_ros.launch

### DIFF
--- a/dialogflow_task_executive/CMakeLists.txt
+++ b/dialogflow_task_executive/CMakeLists.txt
@@ -67,3 +67,8 @@ install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS roslaunch)
+  roslaunch_add_file_check(launch)
+endif()

--- a/dialogflow_task_executive/launch/dialogflow_ros.launch
+++ b/dialogflow_task_executive/launch/dialogflow_ros.launch
@@ -8,6 +8,7 @@
   <arg name="credential" default="$(optenv GOOGLE_APPLICATION_CREDENTIALS)" doc="Read credentials JSON from this value when use_yaml is false." />
   <arg name="project_id" default="$(optenv DIALOGFLOW_PROJECT_ID)"/>
   <arg name="enable_hotword" default="true" />
+  <arg name="always_publish_result" default="true" doc="Always publish dialog_response topic even the node gets actionlib request." />
 
   <node name="dialogflow_client"
         pkg="dialogflow_task_executive" type="dialogflow_client.py"
@@ -21,6 +22,7 @@
       project_id: $(arg project_id)
       google_cloud_credentials_json: $(arg credential)
       enable_hotword: $(arg enable_hotword)
+      always_publish_result: $(arg always_publish_result)
     </rosparam>
     <rosparam command="load" ns="/dialogflow_client/hotword"
               file="$(find dialogflow_task_executive)/config/dialogflow_hotword.yaml"/>

--- a/dialogflow_task_executive/launch/dialogflow_ros.launch
+++ b/dialogflow_task_executive/launch/dialogflow_ros.launch
@@ -8,7 +8,7 @@
   <arg name="credential" default="$(optenv GOOGLE_APPLICATION_CREDENTIALS)" doc="Read credentials JSON from this value when use_yaml is false." />
   <arg name="project_id" default="$(optenv DIALOGFLOW_PROJECT_ID)"/>
   <arg name="enable_hotword" default="true" />
-  <arg name="always_publish_result" default="true" doc="Always publish dialog_response topic even the node gets actionlib request." />
+  <arg name="always_publish_result" default="false" doc="Always publish dialog_response topic even the node gets actionlib request." />
 
   <node name="dialogflow_client"
         pkg="dialogflow_task_executive" type="dialogflow_client.py"

--- a/dialogflow_task_executive/launch/dialogflow_ros.launch
+++ b/dialogflow_task_executive/launch/dialogflow_ros.launch
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <launch>
-  <arg name="launch_dialogflow" default="true" />
   <arg name="use_audio" default="false" />
   <arg name="use_tts" default="true" />
   <arg name="language" default="ja-JP" />
   <arg name="soundplay_action_name" default="robotsound_jp" />
   <arg name="volume" default="1.0" />
+  <arg name="credential" default="$(optenv GOOGLE_APPLICATION_CREDENTIALS)" doc="Read credentials JSON from this value when use_yaml is false." />
+  <arg name="project_id" default="$(optenv DIALOGFLOW_PROJECT_ID)"/>
+  <arg name="enable_hotword" default="true" />
 
   <node name="dialogflow_client"
         pkg="dialogflow_task_executive" type="dialogflow_client.py"

--- a/dialogflow_task_executive/launch/dialogflow_task_executive.launch
+++ b/dialogflow_task_executive/launch/dialogflow_task_executive.launch
@@ -4,6 +4,7 @@
   <arg name="credential" default="$(optenv GOOGLE_APPLICATION_CREDENTIALS)" doc="Read credentials JSON from this value when use_yaml is false." />
   <arg name="project_id" default="$(optenv DIALOGFLOW_PROJECT_ID)"/>
   <arg name="enable_hotword" default="true" />
+  <arg name="always_publish_result" default="true" doc="Always publish dialog_response topic even the node gets actionlib request." />
 
   <!-- options for dialogflow_client -->
   <arg name="launch_dialogflow" default="true" />
@@ -32,6 +33,7 @@
         project_id: $(arg project_id)
         google_cloud_credentials_json: $(arg credential)
         enable_hotword: $(arg enable_hotword)
+        always_publish_result: $(arg always_publish_result)
       </rosparam>
       <rosparam command="load" ns="/dialogflow_client/hotword"
                 file="$(find dialogflow_task_executive)/config/dialogflow_hotword.yaml"/>

--- a/dialogflow_task_executive/launch/dialogflow_task_executive.launch
+++ b/dialogflow_task_executive/launch/dialogflow_task_executive.launch
@@ -21,23 +21,17 @@
   </node>
 
   <group if="$(arg launch_dialogflow)">
-    <node name="dialogflow_client"
-          pkg="dialogflow_task_executive" type="dialogflow_client.py"
-          output="screen">
-      <rosparam subst_value="true">
-        use_audio: $(arg use_audio)
-        use_tts: $(arg use_tts)
-        language: $(arg language)
-        soundplay_action_name: $(arg soundplay_action_name)
-        volume: $(arg volume)
-        project_id: $(arg project_id)
-        google_cloud_credentials_json: $(arg credential)
-        enable_hotword: $(arg enable_hotword)
-        always_publish_result: $(arg always_publish_result)
-      </rosparam>
-      <rosparam command="load" ns="/dialogflow_client/hotword"
-                file="$(find dialogflow_task_executive)/config/dialogflow_hotword.yaml"/>
-    </node>
+    <include file="$(find dialogflow_task_executive)/launch/dialogflow_ros.launch">
+      <arg name="use_audio" value="$(arg use_audio)" />
+      <arg name="use_tts" value="$(arg use_tts)" />
+      <arg name="language" value="$(arg language)" />
+      <arg name="soundplay_action_name" value="$(arg soundplay_action_name)" />
+      <arg name="volume" value="$(arg volume)" />
+      <arg name="credential" value="$(arg credential)" />
+      <arg name="project_id" value="$(arg project_id)" />
+      <arg name="enable_hotword" value="$(arg enable_hotword)" />
+      <arg name="always_publish_result" value="$(arg always_publish_result)" />
+    </include>
   </group>
 
   <node name="task_executive"

--- a/dialogflow_task_executive/launch/dialogflow_task_executive.launch
+++ b/dialogflow_task_executive/launch/dialogflow_task_executive.launch
@@ -4,7 +4,7 @@
   <arg name="credential" default="$(optenv GOOGLE_APPLICATION_CREDENTIALS)" doc="Read credentials JSON from this value when use_yaml is false." />
   <arg name="project_id" default="$(optenv DIALOGFLOW_PROJECT_ID)"/>
   <arg name="enable_hotword" default="true" />
-  <arg name="always_publish_result" default="true" doc="Always publish dialog_response topic even the node gets actionlib request." />
+  <arg name="always_publish_result" default="false" doc="Always publish dialog_response topic even the node gets actionlib request." />
 
   <!-- options for dialogflow_client -->
   <arg name="launch_dialogflow" default="true" />

--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -83,6 +83,10 @@ class DialogflowBase(object):
             )
         if self.project_id is None:
             rospy.logerr('project ID is not set')
+        self.pub_res = rospy.Publisher(
+            "dialog_response", DialogResponse, queue_size=1)
+        self.always_publish_result = rospy.get_param(
+            "~always_publish_result", True)
 
     def detect_intent_text(self, data, session):
         query = df.types.QueryInput(
@@ -143,6 +147,8 @@ class DialogflowTextClient(DialogflowBase):
             self._as.publish_feedback(feedback)
             result.done = success
             self._as.set_succeeded(result)
+            if df_result and self.always_publish_result:
+                self.pub_res.publish(result.response)
 
 
 class DialogflowAudioClient(DialogflowBase):
@@ -184,9 +190,6 @@ class DialogflowAudioClient(DialogflowBase):
                     rospy.Duration(0.1), self.speech_timer_cb)
         else:
             self.sound_action = None
-
-        self.pub_res = rospy.Publisher(
-            "dialog_response", DialogResponse, queue_size=1)
 
         if self.use_audio:
             self.audio_config = df.types.InputAudioConfig(

--- a/dialogflow_task_executive/node_scripts/dialogflow_client.py
+++ b/dialogflow_task_executive/node_scripts/dialogflow_client.py
@@ -86,7 +86,7 @@ class DialogflowBase(object):
         self.pub_res = rospy.Publisher(
             "dialog_response", DialogResponse, queue_size=1)
         self.always_publish_result = rospy.get_param(
-            "~always_publish_result", True)
+            "~always_publish_result", False)
 
     def detect_intent_text(self, data, session):
         query = df.types.QueryInput(

--- a/dialogflow_task_executive/package.xml
+++ b/dialogflow_task_executive/package.xml
@@ -19,12 +19,12 @@
   <build_depend>catkin_virtualenv</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>roslaunch</build_depend>
   <run_depend>app_manager</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>speech_recognition_msgs</run_depend>
   <run_depend>topic_tools</run_depend>
   <!-- <run_depend>python-dialogflow-pip</run_depend> install via catkin_virtualenv -->
+  <test_depend>roslaunch</test_depend>
 
   <export>
     <pip_requirements>requirements.txt</pip_requirements>

--- a/dialogflow_task_executive/package.xml
+++ b/dialogflow_task_executive/package.xml
@@ -19,9 +19,11 @@
   <build_depend>catkin_virtualenv</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>roslaunch</build_depend>
   <run_depend>app_manager</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>speech_recognition_msgs</run_depend>
+  <run_depend>topic_tools</run_depend>
   <!-- <run_depend>python-dialogflow-pip</run_depend> install via catkin_virtualenv -->
 
   <export>


### PR DESCRIPTION
- Fixing missing args in `dialogflow_ros.launch` (e27c514504b0db6ff0e0b8238c8fd4a6ac0e2778, 6456fdc6a5bb668c5e002666344ad87e119486a7)
- Adding `always_publish_result` param, for publishing dialogflow result topic even the node gets actionlib request (3f02199f3387c764872eaf81e6c24910a8c6ff2e)

TODO
- [x] Test in real robot
- [x] Add launch arg test