### PR TITLE
Explicit python interpreter in catkin_virtualenv

### DIFF
--- a/dialogflow_task_executive/CMakeLists.txt
+++ b/dialogflow_task_executive/CMakeLists.txt
@@ -51,9 +51,12 @@ if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
   message(WARNING "to prevent upgrading to latest pip, which is not Python2 compatible")
   file(COPY requirements.txt.indigo DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt.indigo requirements.txt)
-  catkin_generate_virtualenv()
+  catkin_generate_virtualenv(PYTHON_INTERPRETER python2)
 else()
-  catkin_generate_virtualenv(INPUT_REQUIREMENTS requirements.in)
+  catkin_generate_virtualenv(
+    INPUT_REQUIREMENTS requirements.in
+    PYTHON_INTERPRETER python2
+    )
 endif()
 
 file(GLOB NODE_SCRIPTS_FILES node_scripts/*.py)

--- a/ros_speech_recognition/CMakeLists.txt
+++ b/ros_speech_recognition/CMakeLists.txt
@@ -19,7 +19,9 @@ if($ENV{ROS_DISTRO} STREQUAL "noetic")
     PYTHON_INTERPRETER python3
     )
 else()
-  catkin_generate_virtualenv()
+  catkin_generate_virtualenv(
+    PYTHON_INTERPRETER python2
+    )
 endif()
 
 file(GLOB SCRIPT_PROGRAMS scripts/*.py)

--- a/sesame_ros/CMakeLists.txt
+++ b/sesame_ros/CMakeLists.txt
@@ -20,7 +20,9 @@ catkin_package(
   CATKIN_DEPENDS message_runtime
 )
 
-catkin_generate_virtualenv()
+catkin_generate_virtualenv(
+  PYTHON_INTERPRETER python2
+  )
 
 include_directories()
 


### PR DESCRIPTION
As https://github.com/locusrobotics/catkin_virtualenv/pull/77 , when you use latest `catkin_virtualenv` , the default python interpreter becomes `python3` . So I added `PYTHON_INTERPRETER python2` in all packages that use `catkin_virtualenv` and executed with `python2` . Cc:@a-ichikura