### PR TITLE
[rostwitter] Enable to tweet with 280(hankaku) characters and thread

### DIFF
--- a/rostwitter/python/rostwitter/twitter.py
+++ b/rostwitter/python/rostwitter/twitter.py
@@ -57,22 +57,6 @@ class Twitter(object):
             )
         return 0  # if not a POST or GET request
 
-    def _check_and_split_word(self, text):
-        """Check tweet text length and split it.
-
-        See https://developer.twitter.com/en/docs/counting-characters
-
-        """
-        c = count_tweet_text(text)
-        if c > 280:
-            rospy.logwarn('tweet is too longer > 280 characters.')
-            texts = split_tweet_text(text)
-            if len(texts) > 0:
-                text = texts[0]
-            else:
-                text = ''
-        return text
-
     def _post_update_with_reply(self, texts, in_reply_to_status_id=None):
         for text in texts:
             url = 'https://api.twitter.com/1.1/statuses/update.json'

--- a/rostwitter/python/rostwitter/util.py
+++ b/rostwitter/python/rostwitter/util.py
@@ -1,4 +1,5 @@
 import os
+import unicodedata
 import yaml
 
 import rospy
@@ -22,3 +23,37 @@ def load_oauth_settings(yaml_path):
         akey = key['AKEY']
         asecret = key['ASECRET']
     return ckey, csecret, akey, asecret
+
+
+def count_tweet_text(text):
+    count = 0
+    for c in text:
+        if unicodedata.east_asian_width(c) in 'FWA':
+            count += 2
+        else:
+            count += 1
+    return count
+
+
+def split_tweet_text(text, length=280):
+    texts = []
+    split_text = ''
+    count = 0
+    for c in text:
+        if count == 281:
+            # last word is zenkaku.
+            texts.append(split_text[:-1])
+            split_text = split_text[-1:]
+            count = 2
+        elif count == 280:
+            texts.append(split_text)
+            split_text = ''
+            count = 0
+        split_text += c
+        if unicodedata.east_asian_width(c) in 'FWA':
+            count += 2
+        else:
+            count += 1
+    if count != 0:
+        texts.append(split_text)
+    return texts

--- a/rostwitter/python/rostwitter/util.py
+++ b/rostwitter/python/rostwitter/util.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unicodedata
 import yaml
 
@@ -27,6 +28,8 @@ def load_oauth_settings(yaml_path):
 
 def count_tweet_text(text):
     count = 0
+    if sys.version_info.major <= 2:
+        text = text.decode('utf-8')
     for c in text:
         if unicodedata.east_asian_width(c) in 'FWA':
             count += 2
@@ -39,6 +42,8 @@ def split_tweet_text(text, length=280):
     texts = []
     split_text = ''
     count = 0
+    if sys.version_info.major <= 2:
+        text = text.decode('utf-8')
     for c in text:
         if count == 281:
             # last word is zenkaku.


### PR DESCRIPTION
# What is this?

The current implementation only allows tweets of up to 140 characters, regardless of whether they are half-width or full-width.
Changed so that we can tweet up to 280 half-width characters and 140 full-width characters.

https://twitter.com/pr2jsk/status/1559439675559149568

Also, this PR enables thread tweet by using reply.
Changed so that strings longer than 140 characters are displayed as a thread.
https://twitter.com/pr2jsk/status/1559451846418530305