### PR TITLE
[rostwitter] Suppress tweet log

### DIFF
--- a/rostwitter/scripts/tweet.py
+++ b/rostwitter/scripts/tweet.py
@@ -28,7 +28,7 @@ class Tweet(object):
 
     def tweet_cb(self, msg):
         message = msg.data
-        rospy.loginfo(rospy.get_name() + " sending %s", message)
+        rospy.logdebug(rospy.get_name() + " sending %s", message)
 
         # search word start from / and end with {.jpeg,.jpg,.png,.gif}
         m = re.search('/\S+\.(jpeg|jpg|png|gif)', message)

--- a/rostwitter/scripts/tweet.py
+++ b/rostwitter/scripts/tweet.py
@@ -28,7 +28,9 @@ class Tweet(object):
 
     def tweet_cb(self, msg):
         message = msg.data
-        rospy.logdebug(rospy.get_name() + " sending %s", message)
+        # base64 messages are noisy, so tweet log is suppressed
+        rospy.loginfo(rospy.get_name() + " sending %s",
+                      ''.join([message] if len(message) < 128 else message[0:128]+'......'))
 
         # search word start from / and end with {.jpeg,.jpg,.png,.gif}
         m = re.search('/\S+\.(jpeg|jpg|png|gif)', message)


### PR DESCRIPTION
Duplicates of https://github.com/knorth55/jsk_3rdparty/pull/33

This PR suppresses tweet log.
If Base64 encoding texts are displayed in logs, logs are too dirty to see.