### PR TITLE
[ros_ speech_recognition] update default arg for speech_recognition.launch

### DIFF
--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -1,5 +1,4 @@
-ros_speech_recognition
-======================
+# ros\_speech\_recognition
 
 A ROS package for speech-to-text services.  
 This package uses Python package [SpeechRecognition](https://pypi.python.org/pypi/SpeechRecognition) as a backend.
@@ -18,21 +17,22 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
   roslaunch ros_speech_recognition speech_recognition.launch
   ```
   
-3. Use from Python
+3. Echo `/speech_to_text`
 
-  ```python
-  import rospy
-  from ros_speech_recognition import SpeechRecognitionClient
-  
-  rospy.init_node("client")
-  client = SpeechRecognitionClient()
-  result = client.recognize()  # Please say 'Hello, world!' towards microphone
-  print result # => 'Hello, world!'
+  ```bash
+  rostopic echo /speech_to_text
+  # you can get the recognition result
   ```
   
-## Interface
+## `speech_recognition_node.py` Interface
 
 ### Publishing Topics
+
+* `~voice_topic` (`sound_recognition_msgs/SpeechReconitionCandidates`)
+
+  Speech recognition candidates topic name.
+
+  Topic name is set by parameter  `~voice_topic`, and default value is `speech_to_text`.
 
 * `sound_play` (`sound_play/SoundRequestAction`)
 
@@ -40,9 +40,11 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
   
 ### Subscribing Topics
 
-* `audio` (`audio_common_msgs/AudioData`)
+* `~audio_topic` (`audio_common_msgs/AudioData`)
 
   Audio stream data to be recognized.
+
+  Topis name is set by parameter  `~audio_topic` and default value is `audio`.
 
 ### Advertising Services
 
@@ -50,7 +52,27 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
   Service for speech recognition
 
+* `speech_recognition/start` (`std_srvs/Empty`)
+
+  Start service for speech recognition
+
+  This service is available when parameter `~contiunous` is `True`.
+
+* `speech_recognition/start` (`std_srvs/Empty`)
+
+  Stop service for speech recognition
+
+  This service is available when parameter `~contiunous` is `True`.
+
 ## Parameters
+
+* `~voice_topic` (`String`, default: `speech_to_text`)
+
+  Publishing voice topic name
+
+* `~audio_topic` (`String`, default: `audio`)
+
+  Subscribing audio topic name
 
 * `~enable_sound_effect` (`Bool`, default: `True`)
 
@@ -108,10 +130,6 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 
   Seconds of waiting for speech
 
-* `~audio_topic` (`String`, default: `audio`)
-
-  Topic name of input audio data
-  
 * `~depth` (`Int`, default: `16`)
 
   Depth of audio signal
@@ -147,6 +165,10 @@ This package uses Python package [SpeechRecognition](https://pypi.python.org/pyp
 * `~continuous` (`Bool`, default: False)
 
   Selecting to use topic or service. By default, service is used.
+
+* `~auto_start` (`Bool`, default: True)
+
+  Starting the speech recognition when launching.
 
 * `~self_cancellation` (`Bool`, default: `True`)
 

--- a/ros_speech_recognition/launch/speech_recognition.launch
+++ b/ros_speech_recognition/launch/speech_recognition.launch
@@ -3,14 +3,15 @@
   <arg name="launch_audio_capture" default="true" doc="Launch audio_capture node to publish audio topic from microphone" />
 
   <arg name="audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
-  <arg name="voice_topic" default="/Tablet/voice" doc="Name of text topic of recognized speech" />
+  <arg name="voice_topic" default="/speech_to_text" doc="Name of text topic of recognized speech" />
   <arg name="n_channel" default="1" doc="Number of channels of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
   <arg name="depth" default="16" doc="Bit depth of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
   <arg name="sample_rate" default="16000" doc="Frame rate of audio topic and microphone. '$ pactl list short sinks' to check your hardware"/>
   <arg name="device" default="" doc="Card and device number of microphone (e.g. hw:0,0). you can check card number and device number by '$ arecord -l', then uses hw:[card number],[device number]" />
   <arg name="engine" default="Google" doc="Speech to text engine. TTS engine, Google, GoogleCloud, Sphinx, Wit, Bing Houndify, IBM" />
   <arg name="language" default="en-US" doc="Speech to text language. For Japanese, set ja-JP." />
-  <arg name="continuous" default="false" doc="If false, /speech_recognition service is published. If true, /Tablet/voice topic is published." />
+  <arg name="continuous" default="true" doc="If false, /speech_recognition service is published. If true, /speech_to_text topic is published." />
+  <arg name="auto_start" default="true" doc="Whether speech_recognition starts automatically or not. This parameter works when continuous is true" />
 
   <arg name="self_cancellation" default="true" doc="Do not recognize the audio when robot is speaking or not." />
   <arg name="tts_tolerance" default="1.0" doc="Tolerance second for recognizing whether robot is speaking or not" />
@@ -50,6 +51,7 @@
       engine: $(arg engine)
       language: $(arg language)
       continuous: $(arg continuous)
+      auto_start: $(arg auto_start)
       enable_sound_effect: $(arg launch_sound_play)
       self_cancellation: $(arg self_cancellation)
       tts_tolerance: $(arg tts_tolerance)

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -178,7 +178,7 @@ class ROSSpeechRecognition(object):
         if self.continuous:
             rospy.loginfo("Enabled continuous mode")
             rospy.loginfo("Auto start: {}".format(self.auto_start))
-            self.pub = rospy.Publisher(rospy.get_param("~voice_topic", "/Tablet/voice"),
+            self.pub = rospy.Publisher(rospy.get_param("~voice_topic", "speech_to_text"),
                                        SpeechRecognitionCandidates,
                                        queue_size=1)
             self.start_srv = rospy.Service(

--- a/ros_speech_recognition/test/sample_ros_speech_recognition.test
+++ b/ros_speech_recognition/test/sample_ros_speech_recognition.test
@@ -13,6 +13,7 @@
     <arg name="audio_topic" value="/speech_audio" />
     <arg name="language" value="ja" />
     <arg name="continuous" value="true" />
+    <arg name="voice_topic" value="/Tablet/voice" />
   </include>
 
   <!-- launch bag file -->


### PR DESCRIPTION
this PR changes the default value for `speech_recognition.launch`.
with this change, speech_recognition.launch automatically starts and recognized results are published in /speech_to_text topic.

without this PR, we need to run `rosservice call /~~~` to start `speech_recognition` node and the output topic is published in `/Tablet/voice`.