### PR TITLE
[zdepth, zdepth_image_transport] fix zdepth package version to 2.1.24

### DIFF
--- a/3rdparty/zdepth/package.xml
+++ b/3rdparty/zdepth/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>zdepth</name>
-  <version>0.0.0</version>
+  <version>2.1.24</version>
   <description>The zdepth package</description>
 
   <maintainer email="shingogo.5511@gmail.com">Shingo Kitagawa</maintainer>

--- a/zdepth_image_transport/package.xml
+++ b/zdepth_image_transport/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>zdepth_image_transport</name>
-  <version>0.0.0</version>
+  <version>2.1.24</version>
   <description>The zdepth_image_transport package</description>
 
   <maintainer email="shingogo.5511@gmail.com">Shingo Kitagawa</maintainer>


### PR DESCRIPTION
the version number of `zdepth` and `zdepth_image_transport` is now `0.0.0`.
this PR change it to `2.1.24`, same as `jsk_3rdparty`.