### PR TITLE
[respeaker_ros] add FileNotFoundError in respeaker for python3

### DIFF
--- a/respeaker_ros/scripts/respeaker_node.py
+++ b/respeaker_ros/scripts/respeaker_node.py
@@ -21,7 +21,7 @@ from std_msgs.msg import Bool, Int32, ColorRGBA
 from dynamic_reconfigure.server import Server
 try:
     from pixel_ring import usb_pixel_ring_v2
-except IOError as e:
+except (IOError, FileNotFoundError) as e:
     rospy.logerr(e)
     raise RuntimeError("Check the device is connected and recognized")
 


### PR DESCRIPTION
when the device is not found, the raised error is `FileNotFoundError`, not `IOError` in Python3.
this PR changes to catch the `FileNotFoundError`.