### PR TITLE
[gdrive_ros] fix sys.version error

### DIFF
--- a/gdrive_ros/node_scripts/gdrive_server_node.py
+++ b/gdrive_ros/node_scripts/gdrive_server_node.py
@@ -21,7 +21,7 @@ from gdrive_ros.srv import Upload
 from gdrive_ros.srv import UploadResponse
 
 
-if sys.version_info < 3 and \
+if sys.version_info.major < 3 and \
         LooseVersion(pkg_resources.get_distribution("rsa").version) \
         >= LooseVersion('4.6.0'):
     print('''rsa < 4.6.0 is required:


### PR DESCRIPTION
in python3, `sys.version` cannot be compared with int `3`.
this PR fixes the issue.

```python
In [4]: sys.version_info < 3                       
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-4a285b5ed8a1> in <module>
----> 1 sys.version_info < 3

TypeError: '<' not supported between instances of 'sys.version_info' and 'int'
```

```python
In [5]: sys.version_info.major < 3                 
Out[5]: False

```