### PR TITLE
[ros_speech_recognition] Return if result is empty

### DIFF
--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -288,7 +288,7 @@ class ROSSpeechRecognition(object):
             rospy.logdebug("Waiting for result... (Sent %d bytes)" % len(audio.get_raw_data()))
             result = self.recognize(audio)
             confidence = 1.0
-            if result == []: return
+            if len(result) == 0: return
             if self.engine == Config.SpeechRecognition_Google:
                 confidence = result['alternative'][0]['confidence']
                 result = result['alternative'][0]['transcript']

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -288,6 +288,7 @@ class ROSSpeechRecognition(object):
             rospy.logdebug("Waiting for result... (Sent %d bytes)" % len(audio.get_raw_data()))
             result = self.recognize(audio)
             confidence = 1.0
+            if result == []: return
             if self.engine == Config.SpeechRecognition_Google:
                 confidence = result['alternative'][0]['confidence']
                 result = result['alternative'][0]['transcript']


### PR DESCRIPTION
Speech recognition result came to return empty list `[]` by https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/434 and it causes the following error. 

`[ERROR] [1678890951.445378]: Unexpected error: (<type 'exceptions.TypeError'>, TypeError('list indices must be integers, not str',), <traceback object at 0x7f5168a77f00>)`
I fixed it. 