### PR TITLE
[rostwitter] use sub and not delete

### DIFF
--- a/rostwitter/scripts/tweet_image_server.py
+++ b/rostwitter/scripts/tweet_image_server.py
@@ -70,7 +70,7 @@ class TweetImageServer(object):
             self.image_topic_name = goal.image_topic_name
             with self.lock:
                 self.img[self.image_topic_name] = None
-            self.sub = rospy.Subscriber(
+            sub = rospy.Subscriber(
                 self.image_topic_name, Image,
                 self._image_cb)
 
@@ -130,8 +130,7 @@ class TweetImageServer(object):
             else:
                 rospy.logerr('cannot subscribe image: {}'.format(self.image_topic_name))
                 ret = self.api.post_update(goal.text)
-            self.sub.unregister()
-            del self.sub
+            sub.unregister()
         else:
             ret = self.api.post_update(goal.text)
 


### PR DESCRIPTION
this PR change to use `sub` instead of `self.sub`.
with this chage, `sub` will always be removed when `callback` exits.
this prevents subscribing the topic forever.