### PR TITLE
[dialogflow_task_executive] not use map for python3 in task_executive

### DIFF
--- a/dialogflow_task_executive/node_scripts/task_executive.py
+++ b/dialogflow_task_executive/node_scripts/task_executive.py
@@ -82,8 +82,7 @@ class AppManager(object):
 
     @property
     def running_apps(self):
-        return map(lambda a: a.name,
-                   self._latest_msg.running_apps)
+        return [a.name for a in self._latest_msg.running_apps]
 
     @property
     def available_apps(self):


### PR DESCRIPTION
`map` is not evaluated in `task_executive.py`, which cause the error in python3.
this PR use `list` instead of `map` for python3

```
[rosout][ERROR] 2023-03-26 00:07:22,324: bad callback: <bound method TaskExecutive.dialog_cb of <__main__.TaskExecutive object at 0x7f34b97ad820>>
Traceback (most recent call last):                                                                   
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback     
    cb(msg)                                        
  File "/home/applications/ros/noetic/src/jsk-ros-pkg/jsk_3rdparty/dialogflow_task_executive/node_scripts/task_executive.py", line 190, in dialog_cb
    if not self.is_idle:                                                                             
  File "/home/applications/ros/noetic/src/jsk-ros-pkg/jsk_3rdparty/dialogflow_task_executive/node_scripts/task_executive.py", line 183, in is_idle
    return len(self.app_manager.running_apps) == 0                                                   
TypeError: object of type 'map' has no len() 
```