### PR TITLE
[ros_speech_recognition] add ubuntu-sounds dependency

### DIFF
--- a/ros_speech_recognition/package.xml
+++ b/ros_speech_recognition/package.xml
@@ -22,6 +22,7 @@
   <run_depend>flac</run_depend>
   <run_depend>sound_play</run_depend>
   <run_depend>speech_recognition_msgs</run_depend>
+  <run_depend>ubuntu-sounds</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>roslaunch</test_depend>


### PR DESCRIPTION
Add `ubuntu-sounds` dependency to fix https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/452.

Wait for merging https://github.com/ros/rosdistro/pull/36857