### PR TITLE
[influxdb_store] fix package deps for python3

### DIFF
--- a/influxdb_store/package.xml
+++ b/influxdb_store/package.xml
@@ -15,9 +15,11 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>pr2_msgs</exec_depend>
-  <exec_depend>python-influxdb</exec_depend>
-  <exec_depend>python-tz</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-influxdb</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-influxdb</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tz</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tz</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Waiting for https://github.com/ros/rosdistro/pull/36912 to be merged.

Fix the error below:
```
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/doc/create_doc_task_generator.py", line 21, in <module>
    run_module('ros_buildfarm.scripts.doc.create_doc_task_generator', run_name='__main__')
  File "/usr/lib/python3.8/runpy.py", line 210, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/doc/create_doc_task_generator.py", line 714, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/doc/create_doc_task_generator.py", line 561, in main
    debian_pkg_names_depends = resolve_names(depends, **context)
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/doc/create_doc_task_generator.py", line 696, in resolve_names
    resolved_names = resolve_for_os(
  File "/usr/lib/python3/dist-packages/rosdep2/catkin_support.py", line 91, in resolve_for_os
    inst_key, rule = d.get_rule_for_platform(os_name, os_version, os_installers, default_os_installer)
  File "/usr/lib/python3/dist-packages/rosdep2/lookup.py", line 138, in get_rule_for_platform
    raise ResolutionError(rosdep_key, self.data, queried_os, queried_ver, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
rosdep2.lookup.ResolutionError: No definition of [python-influxdb] for OS version [focal]
        rosdep key : python-influxdb
        OS name    : ubuntu
        OS version : focal
        Data:
debian:
                  buster:
                  - python-influxdb
                nixos:
                - pythonPackages.influxdb
                ubuntu:
                  bionic:
                  - python-influxdb
```

