### PR TITLE
add self.conf_thresh in __init__ function

### DIFF
--- a/ros_speech_recognition/scripts/parrot_node.py
+++ b/ros_speech_recognition/scripts/parrot_node.py
@@ -20,7 +20,7 @@ class ParrotNode(object):
             blocking=True,
             sound_action=tts_action_name,
         )
-        self.conf_thresh = rospy.get_param('~confidence_threshold','sound_play')
+        self.conf_thresh = rospy.get_param('~confidence_threshold',0.8)
 
     def _sub_cb(self, msg):
         if len(msg.confidence) > 0:

--- a/ros_speech_recognition/scripts/parrot_node.py
+++ b/ros_speech_recognition/scripts/parrot_node.py
@@ -20,6 +20,7 @@ class ParrotNode(object):
             blocking=True,
             sound_action=tts_action_name,
         )
+        self.conf_thresh = rospy.get_param('~confidence_threshold','sound_play')
 
     def _sub_cb(self, msg):
         if len(msg.confidence) > 0:


### PR DESCRIPTION
add `self.conf_thresh` in __init__ function. If it doesn't include this variable in __init__, parrot.launch doesn't print recognized words.