### PR TITLE
[respeaker_ros] importing does not succeed

### DIFF
--- a/respeaker_ros/scripts/respeaker_node.py
+++ b/respeaker_ros/scripts/respeaker_node.py
@@ -2,65 +2,7 @@
 # -*- coding: utf-8 -*-
 # Author: furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
-import angles
-from contextlib import contextmanager
-import usb.core
-import usb.util
-import pyaudio
-import math
-import numpy as np
-import tf.transformations as T
-import os
-import rospy
-import struct
-import sys
-import time
-from audio_common_msgs.msg import AudioData
-from geometry_msgs.msg import PoseStamped
-from std_msgs.msg import Bool, Int32, ColorRGBA
-from dynamic_reconfigure.server import Server
-
-# https://stackoverflow.com/questions/21367320/searching-for-equivalent-of-filenotfounderror-in-python-2
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
-try:
-    from pixel_ring import usb_pixel_ring_v2
-except (IOError, FileNotFoundError) as e:
-    rospy.logerr(e)
-    raise RuntimeError("Check the device is connected and recognized")
-
-try:
-    from respeaker_ros.cfg import RespeakerConfig
-except Exception as e:
-    rospy.logerr(e)
-    raise RuntimeError("Need to run respeaker_gencfg.py first")
-
 from respeaker_ros import *
-
-# suppress error messages from ALSA
-# https://stackoverflow.com/questions/7088672/pyaudio-working-but-spits-out-error-messages-each-time
-# https://stackoverflow.com/questions/36956083/how-can-the-terminal-output-of-executables-run-by-python-functions-be-silenced-i
-@contextmanager
-def ignore_stderr(enable=True):
-    if enable:
-        devnull = None
-        try:
-            devnull = os.open(os.devnull, os.O_WRONLY)
-            stderr = os.dup(2)
-            sys.stderr.flush()
-            os.dup2(devnull, 2)
-            try:
-                yield
-            finally:
-                os.dup2(stderr, 2)
-                os.close(stderr)
-        finally:
-            if devnull is not None:
-                os.close(devnull)
-    else:
-        yield
 
 
 class RespeakerNode(object):

--- a/respeaker_ros/src/respeaker_ros/__init__.py
+++ b/respeaker_ros/src/respeaker_ros/__init__.py
@@ -1,3 +1,61 @@
+import angles
+from contextlib import contextmanager
+import usb.core
+import usb.util
+import pyaudio
+import math
+import numpy as np
+import tf.transformations as T
+import os
+import rospy
+import struct
+import sys
+import time
+from audio_common_msgs.msg import AudioData
+from geometry_msgs.msg import PoseStamped
+from std_msgs.msg import Bool, Int32, ColorRGBA
+from dynamic_reconfigure.server import Server
+
+# https://stackoverflow.com/questions/21367320/searching-for-equivalent-of-filenotfounderror-in-python-2
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+try:
+    from pixel_ring import usb_pixel_ring_v2
+except (IOError, FileNotFoundError) as e:
+    rospy.logerr(e)
+    raise RuntimeError("Check the device is connected and recognized")
+
+try:
+    from respeaker_ros.cfg import RespeakerConfig
+except Exception as e:
+    rospy.logerr(e)
+    raise RuntimeError("Need to run respeaker_gencfg.py first")
+
+# suppress error messages from ALSA
+# https://stackoverflow.com/questions/7088672/pyaudio-working-but-spits-out-error-messages-each-time
+# https://stackoverflow.com/questions/36956083/how-can-the-terminal-output-of-executables-run-by-python-functions-be-silenced-i
+@contextmanager
+def ignore_stderr(enable=True):
+    if enable:
+        devnull = None
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            stderr = os.dup(2)
+            sys.stderr.flush()
+            os.dup2(devnull, 2)
+            try:
+                yield
+            finally:
+                os.dup2(stderr, 2)
+                os.close(stderr)
+        finally:
+            if devnull is not None:
+                os.close(devnull)
+    else:
+        yield
+
 # Partly copied from https://github.com/respeaker/usb_4_mic_array
 # parameter list
 # name: (id, offset, type, max, min , r/w, info)


### PR DESCRIPTION
Currently, `roslaunch respeaker_ros sample_respeaker.launch` does not work on melodic, Python 2.7.17:
```
$ roslaunch respeaker_ros sample_respeaker.launch
... logging to /home/s-kim/.ros/log/527508b6-08f4-11ee-be1d-8cdcd433896d/roslaunch-hirovision-29439.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://133.11.216.127:37411/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.13
 * /speech_to_text/language: en-US
 * /speech_to_text/self_cancellation: True
 * /speech_to_text/tts_tolerance: 0.5

NODES
  /
    respeaker_node (respeaker_ros/respeaker_node.py)
    sound_play (sound_play/soundplay_node.py)
    speech_to_text (respeaker_ros/speech_to_text.py)
    static_transformer (tf/static_transform_publisher)

auto-starting new master
process[master]: started with pid [29451]
ROS_MASTER_URI=http://hirovision:11311

setting /run_id to 527508b6-08f4-11ee-be1d-8cdcd433896d
process[rosout-1]: started with pid [29463]
started core service [/rosout]
process[static_transformer-2]: started with pid [29467]
process[respeaker_node-3]: started with pid [29476]
process[sound_play-4]: started with pid [29477]
process[speech_to_text-5]: started with pid [29478]
Traceback (most recent call last):
  File "/home/s-kim/hiro_ws/src/jsk_3rdparty/respeaker_ros/scripts/respeaker_node.py", line 201, in <module>
    n = RespeakerNode()
  File "/home/s-kim/hiro_ws/src/jsk_3rdparty/respeaker_ros/scripts/respeaker_node.py", line 79, in __init__
    self.respeaker = RespeakerInterface()
  File "<string>", line 55, in __init__
NameError: global name 'usb' is not defined
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/core.py", line 572, in signal_shutdown
    h()
  File "/home/s-kim/hiro_ws/src/jsk_3rdparty/respeaker_ros/scripts/respeaker_node.py", line 106, in on_shutdown
    self.info_timer.shutdown()
AttributeError: 'RespeakerNode' object has no attribute 'info_timer'
Exception in thread Thread-5 (most likely raised during interpreter shutdown):[respeaker_node-3] process has died [pid 29476, exit code 1, cmd /home/s-kim/hiro_ws/devel/lib/respeaker_ros/respeaker_node.py __name:=respeaker_node __log:=/home/s-kim/.ros/log/527508b6-08f4-11ee-be1d-8cdcd433896d/respeaker_node-3.log].
log file: /home/s-kim/.ros/log/527508b6-08f4-11ee-be1d-8cdcd433896d/respeaker_node-3*.log
^C[speech_to_text-5] killing on exit
[sound_play-4] killing on exit
[respeaker_node-3] killing on exit
[static_transformer-2] killing on exit
^C[rosout-1] killing on exit
^C^C[master] killing on exit
^C^Cshutting down processing monitor...
... shutting down processing monitor complete
done
```

This seems due to https://github.com/jsk-ros-pkg/jsk_3rdparty/commit/4ea7e8bfa5332999628a531c8d3fa0be2ac02601 and this PR fixes the error by moving all `import` into `__init__.py`.
But I'm not sure this is a correct way to fix.