### PR TITLE
fix build farm

### DIFF
--- a/3rdparty/julius/Makefile.dictation-kit
+++ b/3rdparty/julius/Makefile.dictation-kit
@@ -5,7 +5,7 @@ all: installed.dict
 VERSION = 4.4
 FILENAME = dictation-kit-v$(VERSION).zip
 TARBALL = build/$(FILENAME)
-TARBALL_URL = "https://osdn.jp/dl/julius/$(FILENAME)"
+TARBALL_URL = "https://github.com/jsk-ros-pkg/archives/raw/master/$(FILENAME)"
 TARBALL_PATCH =
 SOURCE_DIR = build/dictation-kit-v$(VERSION)
 UNPACK_CMD = unzip -qq

--- a/3rdparty/julius/Makefile.grammar-kit
+++ b/3rdparty/julius/Makefile.grammar-kit
@@ -5,7 +5,7 @@ all: installed.grammar-kit
 VERSION = 4.3.1
 FILENAME = grammar-kit-v$(VERSION).tar.gz
 TARBALL = build/$(FILENAME)
-TARBALL_URL = "https://github.com/julius-speech/grammar-kit/archive/v$(VERSION).tar.gz"
+TARBALL_URL = "https://github.com/jsk-ros-pkg/archives/raw/master/$(FILENAME)"
 TARBALL_PATCH =
 SOURCE_DIR = build/grammar-kit-$(VERSION)
 UNPACK_CMD = tar xf

--- a/3rdparty/julius/Makefile.julius
+++ b/3rdparty/julius/Makefile.julius
@@ -5,7 +5,7 @@ all: installed.julius
 VERSION = 4.4.2
 FILENAME = julius-$(VERSION).tar.gz
 TARBALL = build/$(FILENAME)
-TARBALL_URL = "https://github.com/julius-speech/julius/archive/v$(VERSION).tar.gz"
+TARBALL_URL = "https://github.com/jsk-ros-pkg/archives/raw/master/$(FILENAME)"
 PATCH_DIR = $(CURDIR)/patch
 TARBALL_PATCH = $(PATCH_DIR)/config.patch $(PATCH_DIR)/aarch64.patch
 SOURCE_DIR = build/julius-$(VERSION)

--- a/3rdparty/zdepth/package.xml
+++ b/3rdparty/zdepth/package.xml
@@ -9,6 +9,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
 
 
   <export>


### PR DESCRIPTION
165fe7fb (Kei Okada, 89 seconds ago)     julius: fix location URLs, because osdn is too slow
231fbf4c (Kei Okada, 70 minutes ago)     zdepth  ROS_DISTRO needs ros_environment

lpg_planner and respeaker_ros need to skip shdebs  https://github.com/tork-a/jsk_3rdparty-release/blob/patches/debian/noetic/respeaker_ros/0001-buildfirm-error-due-to-pkg-shlibdeps-error-cannot-fi.patch

![Screenshot from 2023-07-21 15-10-47](https://github.com/jsk-ros-pkg/jsk_3rdparty/assets/493276/b846b51a-9dbf-4db2-bb79-f32448c18383)
