### PR TITLE
Mod for switchbot api 1.1

### DIFF
--- a/switchbot_ros/launch/switchbot.launch
+++ b/switchbot_ros/launch/switchbot.launch
@@ -1,11 +1,13 @@
 <launch>
   <arg name="token" />
+  <arg name="secret" />
   <arg name="respawn" default="true" />
 
   <node name="switchbot_ros" pkg="switchbot_ros" type="switchbot_ros_server.py"
         respawn="$(arg respawn)" output="screen">
     <rosparam subst_value="true">
       token: $(arg token)
+      secret: $(arg secret)
     </rosparam>
   </node>
 </launch>

--- a/switchbot_ros/launch/switchbot.launch
+++ b/switchbot_ros/launch/switchbot.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="token" />
-  <arg name="secret" default="secret_none" />
+  <arg name="secret" default="''" />
   <arg name="respawn" default="true" />
 
   <node name="switchbot_ros" pkg="switchbot_ros" type="switchbot_ros_server.py"

--- a/switchbot_ros/launch/switchbot.launch
+++ b/switchbot_ros/launch/switchbot.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="token" />
-  <arg name="secret" />
+  <arg name="secret" default="secret_none" />
   <arg name="respawn" default="true" />
 
   <node name="switchbot_ros" pkg="switchbot_ros" type="switchbot_ros_server.py"

--- a/switchbot_ros/scripts/control_switchbot.py
+++ b/switchbot_ros/scripts/control_switchbot.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import rospy
+from switchbot_ros.switchbot_ros_client import SwitchBotROSClient
+
+rospy.init_node('controler_node')
+client = SwitchBotROSClient()
+
+devices = client.get_devices()
+print(devices)
+
+client.control_device('pendant-light', 'turnOff')
+
+client.control_device('bot74a', 'turnOn')
+

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -37,7 +37,9 @@ class SwitchBotAction:
 
         # Initialize switchbot client
         self.bots = self.get_switchbot_client()
+        self.print_baseurl()
         self.print_devices()
+        self.print_scenes()
         # Actionlib
         self._as = actionlib.SimpleActionServer(
             '~switch', SwitchBotCommandAction,
@@ -46,6 +48,7 @@ class SwitchBotAction:
         # Topic
         self.pub = rospy.Publisher('~devices', DeviceArray, queue_size=1, latch=True)
         self.published = False
+        rospy.loginfo('Ready.')
 
     def get_switchbot_client(self):
         try:
@@ -66,6 +69,15 @@ class SwitchBotAction:
                 self.publish_devices()
                 self.published = True
 
+    def print_baseurl(self):
+        if self.bots is None:
+            return
+        
+        base_url_str = 'SwitchBot API Base URL: ';
+        base_url_str += self.bots.host_domain;
+        rospy.loginfo(base_url_str)        
+        
+
     def print_devices(self):
         if self.bots is None:
             return
@@ -73,24 +85,42 @@ class SwitchBotAction:
         device_list_str = 'Switchbot Device List:\n'
         device_list = sorted(
             self.bots.device_list,
-            key=lambda device: str(device['deviceName']))
+            key=lambda device: str(device.get('deviceName')))
+        device_list_str += str(len(device_list)) + ' Item(s)\n'
         for device in device_list:
-            device_list_str += 'deviceName: ' + str(device['deviceName'])
-            device_list_str += ', deviceID: ' + str(device['deviceId'])
-            device_list_str += ', deviceType: ' + str(device['deviceType'])
+            device_list_str += 'deviceName: ' + str(device.get('deviceName'))
+            device_list_str += ', deviceID: ' + str(device.get('deviceId'))
+            device_list_str += ', deviceType: ' + str(device.get('deviceType'))
             device_list_str += '\n'
         rospy.loginfo(device_list_str)
         
         remote_list_str = 'Switchbot Remote List:\n'
         infrared_remote_list = sorted(
             self.bots.infrared_remote_list,
-            key=lambda infrared_remote: str(infrared_remote['deviceName']))
+            key=lambda infrared_remote: str(infrared_remote.get('deviceName')))
+        remote_list_str += str(len(infrared_remote_list)) + ' Item(s)\n'
         for infrared_remote in infrared_remote_list:
-            remote_list_str += 'deviceName: ' + str(infrared_remote['deviceName'])
-            remote_list_str += ', deviceID: ' + str(infrared_remote['deviceId'])
-            remote_list_str += ', remoteType: ' + str(infrared_remote['remoteType'])
+            remote_list_str += 'deviceName: ' + str(infrared_remote.get('deviceName'))
+            remote_list_str += ', deviceID: ' + str(infrared_remote.get('deviceId'))
+            remote_list_str += ', remoteType: ' + str(infrared_remote.get('remoteType'))
             remote_list_str += '\n'
         rospy.loginfo(remote_list_str)
+        
+
+    def print_scenes(self):
+        if self.bots is None:
+            return
+        
+        scene_list_str = 'Switchbot Scene List:\n'
+        scene_list = sorted(
+            self.bots.scene_list,
+            key=lambda scene: str(scene.get('sceneName')))
+        scene_list_str += str(len(scene_list)) + ' Item(s)\n'
+        for scene in scene_list:
+            scene_list_str += 'sceneName: ' + str(scene.get('sceneName'))
+            scene_list_str += ', sceneID: ' + str(scene.get('sceneId'))
+            scene_list_str += '\n'
+        rospy.loginfo(scene_list_str)
         
 
     def publish_devices(self):
@@ -101,20 +131,20 @@ class SwitchBotAction:
         
         device_list = sorted(
             self.bots.device_list,
-            key=lambda device: str(device['deviceName']))
+            key=lambda device: str(device.get('deviceName')))
         for device in device_list:
             msg_device = Device()
-            msg_device.name = str(device['deviceName'])
-            msg_device.type = str(device['deviceType'])
+            msg_device.name = str(device.get('deviceName'))
+            msg_device.type = str(device.get('deviceType'))
             msg.devices.append(msg_device)
         
         infrared_remote_list = sorted(
             self.bots.infrared_remote_list,
-            key=lambda infrared_remote: str(infrared_remote['deviceName']))
+            key=lambda infrared_remote: str(infrared_remote.get('deviceName')))
         for infrared_remote in infrared_remote_list:
             msg_device = Device()
-            msg_device.name = str(infrared_remote['deviceName'])
-            msg_device.type = str(infrared_remote['remoteType'])
+            msg_device.name = str(infrared_remote.get('deviceName'))
+            msg_device.type = str(infrared_remote.get('remoteType'))
             msg.devices.append(msg_device)
         
         self.pub.publish(msg)

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -37,7 +37,7 @@ class SwitchBotAction:
 
         # Initialize switchbot client
         self.bots = self.get_switchbot_client()
-        self.print_baseurl()
+        self.print_apiversion()
         self.print_devices()
         self.print_scenes()
         # Actionlib
@@ -69,12 +69,12 @@ class SwitchBotAction:
                 self.publish_devices()
                 self.published = True
 
-    def print_baseurl(self):
+    def print_apiversion(self):
         if self.bots is None:
             return
         
-        base_url_str = 'SwitchBot API Base URL: ';
-        base_url_str += self.bots.host_domain;
+        base_url_str = 'Using SwitchBot API ';
+        base_url_str += self.bots.api_version;
         rospy.loginfo(base_url_str)        
         
 

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -73,9 +73,9 @@ class SwitchBotAction:
         if self.bots is None:
             return
         
-        base_url_str = 'Using SwitchBot API ';
-        base_url_str += self.bots.api_version;
-        rospy.loginfo(base_url_str)        
+        apiversion_str = 'Using SwitchBot API ';
+        apiversion_str += self.bots.api_version;
+        rospy.loginfo(apiversion_str)        
         
 
     def print_devices(self):

--- a/switchbot_ros/scripts/switchbot_ros_server.py
+++ b/switchbot_ros/scripts/switchbot_ros_server.py
@@ -28,9 +28,9 @@ class SwitchBotAction:
             self.token = token
 
         # Switchbot API v1.1 needs secret key
-        secret = rospy.get_param('~secret')
-        if os.path.exists(secret):
-            with open(secret) as f:
+        secret = rospy.get_param('~secret', None )
+        if secret is not None and os.path.exists(secret):
+            with open(secret, 'r', encoding='utf-8') as f:
                 self.secret = f.read().replace('\n', '')
         else:
             self.secret = secret
@@ -162,7 +162,7 @@ class SwitchBotAction:
             command_type = 'command'
         try:
             if not self.bots:
-                self.bots = SwitchBotAPIClient(token=self.token,secret=self.secret)
+                self.bots = SwitchBotAPIClient(token=self.token, secret=self.secret)
             feedback.status = str(
                 self.bots.control_device(
                     command=goal.command,

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -17,11 +17,12 @@ class SwitchBotAPIClient(object):
     For Using SwitchBot via official API.
     Please see https://github.com/OpenWonderLabs/SwitchBotAPI for details.
     """
-    def __init__(self, token, secret="secret_none"):
-        if secret=="secret_none":
-          self.host_domain = "https://api.switch-bot.com/v1.0/"
+    def __init__(self, token, secret=""):
+        if not secret:
+          self.api_version = "v1.0"
         else:
-          self.host_domain = "https://api.switch-bot.com/v1.1/"
+          self.api_version = "v1.1"
+        self._host_domain = "https://api.switch-bot.com/" + self.api_version + "/"
         self.token = token
         self.secret = secret # SwitchBot API v1.1
         self.device_list = None
@@ -33,7 +34,9 @@ class SwitchBotAPIClient(object):
         self.update_scene_list()
 
     def make_sign(self, token, secret):
-        
+        """
+        Make Sign from token and secret
+        """
         nonce = uuid.uuid4()
         t = int(round(time.time() * 1000))
         string_to_sign = '{}{}{}'.format(token, t, nonce)
@@ -46,7 +49,10 @@ class SwitchBotAPIClient(object):
         return sign, str(t), nonce
 
     def make_request_header(self, token, secret):
-        sign,t,nonce = self.make_sign(token, secret)
+        """
+        Make Request Header
+        """
+        sign, t, nonce = self.make_sign(token, secret)
         headers={
                 "Authorization": token,
                 "sign": str(sign, 'utf-8'),
@@ -63,7 +69,7 @@ class SwitchBotAPIClient(object):
         if devices_or_scenes not in ['devices', 'scenes']:
             raise ValueError('Please set devices_or_scenes variable devices or scenes')
 
-        url = os.path.join(self.host_domain, devices_or_scenes, service_id, service)
+        url = os.path.join(self._host_domain, devices_or_scenes, service_id, service)
         
         headers = self.make_request_header(self.token, self.secret)
 

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -17,8 +17,11 @@ class SwitchBotAPIClient(object):
     For Using SwitchBot via official API.
     Please see https://github.com/OpenWonderLabs/SwitchBotAPI for details.
     """
-    def __init__(self, token, secret):
-        self._host_domain = "https://api.switch-bot.com/v1.1/"
+    def __init__(self, token, secret="secret_none"):
+        if secret=="secret_none":
+          self.host_domain = "https://api.switch-bot.com/v1.0/"
+        else:
+          self.host_domain = "https://api.switch-bot.com/v1.1/"
         self.token = token
         self.secret = secret # SwitchBot API v1.1
         self.device_list = None
@@ -48,7 +51,8 @@ class SwitchBotAPIClient(object):
                 "Authorization": token,
                 "sign": str(sign, 'utf-8'),
                 "t": str(t),
-                "nonce": str(nonce)
+                "nonce": str(nonce),
+                "Content-Type": "application/json; charset=utf8"
                 }
         return headers
 
@@ -59,7 +63,7 @@ class SwitchBotAPIClient(object):
         if devices_or_scenes not in ['devices', 'scenes']:
             raise ValueError('Please set devices_or_scenes variable devices or scenes')
 
-        url = os.path.join(self._host_domain, devices_or_scenes, service_id, service)
+        url = os.path.join(self.host_domain, devices_or_scenes, service_id, service)
         
         headers = self.make_request_header(self.token, self.secret)
 
@@ -129,7 +133,7 @@ class SwitchBotAPIClient(object):
         """
         self.scene_list = self.request(devices_or_scenes='scenes')['body']
         for scene in self.scene_list:
-            self.scene_name_id[scene['sceneName']] = device['sceneId']
+            self.scene_name_id[scene['sceneName']] = scene['sceneId']
 
         return self.scene_list
 

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -32,7 +32,7 @@ class SwitchBotAPIClient(object):
         self.update_device_list()
         self.update_scene_list()
 
-    def make_sign(self, token: str, secret: str):
+    def make_sign(self, token, secret):
         
         nonce = uuid.uuid4()
         t = int(round(time.time() * 1000))
@@ -45,7 +45,7 @@ class SwitchBotAPIClient(object):
                 
         return sign, str(t), nonce
 
-    def make_request_header(self, token: str, secret: str):
+    def make_request_header(self, token, secret):
         sign,t,nonce = self.make_sign(token, secret)
         headers={
                 "Authorization": token,

--- a/switchbot_ros/src/switchbot_ros/switchbot.py
+++ b/switchbot_ros/src/switchbot_ros/switchbot.py
@@ -4,6 +4,7 @@ import json
 import os.path
 import requests
 
+import sys
 import os
 import time
 import hashlib
@@ -41,11 +42,18 @@ class SwitchBotAPIClient(object):
         t = int(round(time.time() * 1000))
         string_to_sign = '{}{}{}'.format(token, t, nonce)
         
-        string_to_sign = bytes(string_to_sign, 'utf-8')
-        secret = bytes(secret, 'utf-8')
+        if sys.version_info[0] > 2:
+            string_to_sign = bytes(string_to_sign, 'utf-8')
+            secret = bytes(secret, 'utf-8')
+        else:
+            string_to_sign = bytes(string_to_sign)
+            secret = bytes(secret)
         
         sign = base64.b64encode(hmac.new(secret, msg=string_to_sign, digestmod=hashlib.sha256).digest())
-                
+        
+        if sys.version_info[0] > 2:
+            sign = sign.decode('utf-8')
+        
         return sign, str(t), nonce
 
     def make_request_header(self, token, secret):
@@ -55,7 +63,7 @@ class SwitchBotAPIClient(object):
         sign, t, nonce = self.make_sign(token, secret)
         headers={
                 "Authorization": token,
-                "sign": str(sign, 'utf-8'),
+                "sign": str(sign),
                 "t": str(t),
                 "nonce": str(nonce),
                 "Content-Type": "application/json; charset=utf8"


### PR DESCRIPTION
- modifications for SwitchBot API v1.0 and v1.1
  - for API v1.0 set only `token` option to `switchbot.launch` the same as before
  - for API v1.1 set both `token` and `secret` options to `switchbot.launch` 
- fix codes around infrared remotes and scenes