### PR TITLE
ros-o support

### DIFF
--- a/3rdparty/libsiftfast/patches/10.boost_python38.patch
+++ b/3rdparty/libsiftfast/patches/10.boost_python38.patch
@@ -2,12 +2,14 @@ Index: CMakeLists.txt
 ===================================================================
 --- CMakeLists.txt	(revision 54)
 +++ CMakeLists.txt	(working copy)
-@@ -155,7 +155,8 @@
+@@ -155,7 +155,10 @@
  if( NOT $ENV{BOOST_LIBRARYDIR} STREQUAL "" )
    set(Boost_LIBRARY_DIRS $ENV{BOOST_LIBRARYDIR})
  endif()
 -find_package(Boost COMPONENTS python)
-+find_package(Boost REQUIRED COMPONENTS system python38)
++set(Python3_FIND_STRATEGY VERSION)
++find_package(Python3 COMPONENTS Interpreter Development)
++find_package(Boost REQUIRED COMPONENTS system python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
 +add_definitions("-Wno-narrowing")
  
  if( Boost_FOUND )
@@ -17,7 +19,7 @@ Index: CMakeLists.txt
  #
  set(BUILD_SIFTFASTPY)
 -if( Boost_PYTHON_FOUND )
-+if( Boost_PYTHON38_FOUND )
++if( Boost_PYTHON${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}_FOUND )
    find_package(PythonLibs)
  
    if( PYTHONLIBS_FOUND OR PYTHON_LIBRARIES )

--- a/sesame_ros/requirements.txt
+++ b/sesame_ros/requirements.txt
@@ -1,6 +1,5 @@
 asn1crypto==1.3.0
 certifi==2020.6.20
-cffi==1.14.0
 chardet==3.0.4
 cryptography==2.3
 enum34==1.1.10


### PR DESCRIPTION
- **[libsiftfast] support multiple python3 version**
- **[sesame_ros] remove cffi which cannot be installed in Ubuntu 22.04 env & not used in sesame_ros**
