### PR TITLE
gdrive_server_node.py: update url format. 

### DIFF
--- a/gdrive_ros/node_scripts/gdrive_server_node.py
+++ b/gdrive_ros/node_scripts/gdrive_server_node.py
@@ -35,7 +35,7 @@ if sys.version_info.major < 3 and \
 class GDriveServerNode(object):
     folder_mime_type = 'application/vnd.google-apps.folder'
     folder_url_format = 'https://drive.google.com/drive/folders/{}'
-    file_url_format = 'https://drive.google.com/uc?id={}'
+    file_url_format = 'https://drive.usercontent.google.com/download?id={}&authuser=0'
 
     def __init__(self):
         settings_yaml = rospy.get_param('~settings_yaml', None)


### PR DESCRIPTION
https://drive.google.com/uc?id={} is user content end point and actual url is https://drive.usercontent.google.com/download?id={}&authuser=0

How to reproduce
1. download credential files (only for JSK users) https://drive.google.com/file/d/1eEoWt_ENWCQsP4WRg475b8JRIX5b8m03/view?usp=drive_link
2. start google drive server
```
roslaunch gdrive_ros gdrive_server.launch settings_yaml:=$(rospack find gdrive_ros)/auth/pydrive_settings.yaml node_name:=gdrive_ros
```
3. start google_chat_ros
```
roslaunch google_chat_ros google_chat.launch google_cloud_credentials_json:=$(rospack find google_chat_ros)/auth/jsk-aibo-37d42e158287.json project_id:=jsk-aibo use_helper:=false receiving_mode:=pubsub subscription_id:=chat-sub
```

4. upload image file to chat, please replace chat space ID depending on your environment (https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/master/google_chat_ros/README.md#21-understanding-google-chat-room)
```
rostopic pub -1 /google_chat_ros/send/goal google_chat_ros/SendMessageActionGoal "{goal: {cards: [{sections: [{widgets: [{image: {localpath: '/usr/share/pixmaps/debian-logo.png'}}]}]}], space: 'spaces/6xotc0AAAAE'}}"
```

<img width="750" height="343" alt="Screenshot from 2025-09-11 18-23-34" src="https://github.com/user-attachments/assets/d4992df2-9ccb-4df1-863c-9cb8b3485aae" />
