### PR TITLE
[respeaker_ros] change frames_per_buffer for webrtcvad

### DIFF
--- a/respeaker_ros/scripts/respeaker_node.py
+++ b/respeaker_ros/scripts/respeaker_node.py
@@ -16,6 +16,7 @@ class RespeakerNode(object):
         self.speech_continuation = rospy.get_param("~speech_continuation", 0.5)
         self.speech_max_duration = rospy.get_param("~speech_max_duration", 7.0)
         self.speech_min_duration = rospy.get_param("~speech_min_duration", 0.1)
+        self.sample_duration = rospy.get_param("~sample_duration", None)  # sec
         suppress_pyaudio_error = rospy.get_param("~suppress_pyaudio_error", True)
         #
         self.respeaker = RespeakerInterface()
@@ -34,7 +35,8 @@ class RespeakerNode(object):
         self.config = None
         self.dyn_srv = Server(RespeakerConfig, self.on_config)
         # start
-        self.respeaker_audio = RespeakerAudio(self.on_audio, suppress_error=suppress_pyaudio_error)
+        self.respeaker_audio = RespeakerAudio(self.on_audio, suppress_error=suppress_pyaudio_error,
+                                              sample_duration=self.sample_duration)
         self.speech_prefetch_bytes = int(
             self.speech_prefetch * self.respeaker_audio.rate * self.respeaker_audio.bitdepth / 8.0)
         self.speech_prefetch_buffer = b""

--- a/respeaker_ros/src/respeaker_ros/__init__.py
+++ b/respeaker_ros/src/respeaker_ros/__init__.py
@@ -232,7 +232,7 @@ class RespeakerInterface(object):
 
 
 class RespeakerAudio(object):
-    def __init__(self, on_audio, channel=0, suppress_error=True):
+    def __init__(self, on_audio, channel=0, suppress_error=True, sample_duration=None):
         self.on_audio = on_audio
         with ignore_stderr(enable=suppress_error):
             self.pyaudio = pyaudio.PyAudio()
@@ -242,6 +242,10 @@ class RespeakerAudio(object):
         self.rate = 16000
         self.bitwidth = 2
         self.bitdepth = 16
+        if sample_duration is not None:
+            frames_per_buffer = int(sample_duration * self.rate)
+        else:
+            frames_per_buffer = 1024
 
         # find device
         count = self.pyaudio.get_device_count()
@@ -272,7 +276,7 @@ class RespeakerAudio(object):
             format=pyaudio.paInt16,
             channels=self.channels,
             rate=self.rate,
-            frames_per_buffer=1024,
+            frames_per_buffer=frames_per_buffer,
             stream_callback=self.stream_callback,
             input_device_index=self.device_index,
         )


### PR DESCRIPTION
矢野倉先生に見ていただき、
webrtcvadは小さいサイズのフレームを想定しているが、respeaker_rosのほうでframe sizeが大きかったため、webrtcvadでの処理ができず、エラーが出ていた。
そこで、respeaker_rosでframe sizeを小さく設定できるように変更している。