### PR TITLE
[ros_speech_recognition] Make speech_recognition.launch work in Ubuntu 24.04

### DIFF
--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -161,19 +161,27 @@ roslaunch ros_speech_recognition parrotry.launch language:=ja-JP
   
 * `~start_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/bell.ogg`)
 
-  Path to sound file for bell on the start of audio caption
+  Path to sound file for bell on the start of audio caption.
+
+  If `*.ogg` is not found, `*.oga` is searched for.
   
 * `~recognized_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/message.ogg`)
 
-  Path to sound file for bell on the end of audio caption
+  Path to sound file for bell on the end of audio caption.
+
+  If `*.ogg` is not found, `*.oga` is searched for.
   
 * `~success_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/message-new-instant.ogg`)
 
-  Path to sound file for bell on getting successful recognition result
+  Path to sound file for bell on getting successful recognition result.
+
+  If `*.ogg` is not found, `*.oga` is searched for.
   
 * `~timeout_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg`)
 
-  Path to sound file for bell on timeout for recognition
+  Path to sound file for bell on timeout for recognition.
+
+  If `*.ogg` is not found, `*.oga` is searched for.
   
 * `~continuous` (`Bool`, default: False)
 

--- a/ros_speech_recognition/README.md
+++ b/ros_speech_recognition/README.md
@@ -159,29 +159,29 @@ roslaunch ros_speech_recognition parrotry.launch language:=ja-JP
 
   Maximum buffer size to store audio data for speech recognition
   
-* `~start_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/bell.ogg`)
+* `~start_signal` (`String`, default: `None`)
 
   Path to sound file for bell on the start of audio caption.
 
-  If `*.ogg` is not found, `*.oga` is searched for.
+  If this is `None`, `/usr/share/sounds/freedesktop/stereo/bell.ogg` or `/usr/share/sounds/freedesktop/stereo/bell.oga` is used.
   
-* `~recognized_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/message.ogg`)
+* `~recognized_signal` (`String`, default: `None`)
 
   Path to sound file for bell on the end of audio caption.
 
-  If `*.ogg` is not found, `*.oga` is searched for.
+  If this is `None`, `/usr/share/sounds/freedesktop/stereo/message.ogg` or `/usr/share/sounds/freedesktop/stereo/message.oga` is used.
   
-* `~success_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/message-new-instant.ogg`)
+* `~success_signal` (`String`, default: `None`)
 
   Path to sound file for bell on getting successful recognition result.
 
-  If `*.ogg` is not found, `*.oga` is searched for.
+  If this is `None`, `/usr/share/sounds/freedesktop/stereo/message-new-instant.ogg` or `/usr/share/sounds/freedesktop/stereo/message-new-instant.oga` is used.
   
-* `~timeout_signal` (`String`, default: `/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg`)
+* `~timeout_signal` (`String`, default: `None`)
 
   Path to sound file for bell on timeout for recognition.
 
-  If `*.ogg` is not found, `*.oga` is searched for.
+  If this is `None`, `/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg` or `/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.oga` is used.
   
 * `~continuous` (`Bool`, default: False)
 

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -107,7 +107,7 @@ class ROSAudio(SR.AudioSource):
                 # take out target_channel channel data from multi channel data
                 data = array.array(dtype, bytes(msg.data)).tolist()
                 chan_data = data[self.target_channel::self.n_channel]
-                self.buffer += array.array(dtype, chan_data).tostring()
+                self.buffer += array.array(dtype, chan_data).tobytes()
                 overflow = len(self.buffer) - self.buffer_size
                 if overflow > 0:
                     self.buffer = self.buffer[overflow:]

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -9,6 +9,7 @@ from ros_speech_recognition.recognize_google_cloud import RecognizerEx
 import ros_speech_recognition.recognize_vosk
 import json
 import array
+import os
 import sys
 from threading import Lock
 
@@ -24,6 +25,20 @@ from std_srvs.srv import EmptyResponse
 
 from dynamic_reconfigure.server import Server
 from ros_speech_recognition.cfg import SpeechRecognitionConfig as Config
+
+
+def resolve_sound_signal_path(path):
+    if os.path.exists(path):
+        return path
+    attempted_paths = [path]
+    base, ext = os.path.splitext(path)
+    if ext == ".ogg":
+        oga_path = base + ".oga"
+        if os.path.exists(oga_path):
+            return oga_path
+        attempted_paths.append(oga_path)
+    raise IOError("Sound signal file not found: {}".format(
+        " or ".join(attempted_paths)))
 
 
 class ROSAudio(SR.AudioSource):
@@ -144,7 +159,11 @@ class ROSSpeechRecognition(object):
             "timeout": rospy.get_param("~timeout_signal",
                                        "/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg"),
         }
-
+        if self.act_sound is not None:
+            self.signals = {
+                key: resolve_sound_signal_path(path)
+                for key, path in self.signals.items()
+            }
 
         # ignore voice input while the robot is speaking
         self.self_cancellation = rospy.get_param("~self_cancellation", True)

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -27,6 +27,15 @@ from dynamic_reconfigure.server import Server
 from ros_speech_recognition.cfg import SpeechRecognitionConfig as Config
 
 
+if hasattr(array.array, 'tobytes'):
+    def array_to_bytes(arr):
+        return arr.tobytes()
+else:
+    # Python 2.7
+    def array_to_bytes(arr):
+        return arr.tostring()
+
+
 def resolve_sound_signal_path(path):
     if os.path.exists(path):
         return path
@@ -122,7 +131,7 @@ class ROSAudio(SR.AudioSource):
                 # take out target_channel channel data from multi channel data
                 data = array.array(dtype, bytes(msg.data)).tolist()
                 chan_data = data[self.target_channel::self.n_channel]
-                self.buffer += array.array(dtype, chan_data).tobytes()
+                self.buffer += array_to_bytes(array.array(dtype, chan_data))
                 overflow = len(self.buffer) - self.buffer_size
                 if overflow > 0:
                     self.buffer = self.buffer[overflow:]

--- a/ros_speech_recognition/scripts/speech_recognition_node.py
+++ b/ros_speech_recognition/scripts/speech_recognition_node.py
@@ -46,8 +46,12 @@ def resolve_sound_signal_path(path):
         if os.path.exists(oga_path):
             return oga_path
         attempted_paths.append(oga_path)
-    raise IOError("Sound signal file not found: {}".format(
-        " or ".join(attempted_paths)))
+    rospy.logwarn(
+        "Sound signal file not found on the machine "
+        "where speech_recognition is running: {}".format(
+            " or ".join(attempted_paths))
+    )
+    return path
 
 
 class ROSAudio(SR.AudioSource):
@@ -159,20 +163,22 @@ class ROSSpeechRecognition(object):
         else:
             self.act_sound = None
         self.signals = {
-            "start": rospy.get_param("~start_signal",
-                                     "/usr/share/sounds/freedesktop/stereo/bell.ogg"),
-            "recognized": rospy.get_param("~recognized_signal",
-                                          "/usr/share/sounds/freedesktop/stereo/message.ogg"),
-            "success": rospy.get_param("~success_signal",
-                                       "/usr/share/sounds/freedesktop/stereo/message-new-instant.ogg"),
-            "timeout": rospy.get_param("~timeout_signal",
-                                       "/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg"),
+            "start": rospy.get_param("~start_signal", None),
+            "recognized": rospy.get_param("~recognized_signal", None),
+            "success": rospy.get_param("~success_signal", None),
+            "timeout": rospy.get_param("~timeout_signal", None),
+        }
+        default_signals = {
+            "start": "/usr/share/sounds/freedesktop/stereo/bell.ogg",
+            "recognized": "/usr/share/sounds/freedesktop/stereo/message.ogg",
+            "success": "/usr/share/sounds/freedesktop/stereo/message-new-instant.ogg",
+            "timeout": "/usr/share/sounds/freedesktop/stereo/network-connectivity-lost.ogg",
         }
         if self.act_sound is not None:
-            self.signals = {
-                key: resolve_sound_signal_path(path)
-                for key, path in self.signals.items()
-            }
+            for key in self.signals.keys():
+                if self.signals[key] is None:
+                    self.signals[key] = resolve_sound_signal_path(
+                        default_signals[key])
 
         # ignore voice input while the robot is speaking
         self.self_cancellation = rospy.get_param("~self_cancellation", True)
@@ -271,7 +277,14 @@ class ROSSpeechRecognition(object):
             req.volume = 1.0
         req.arg = self.signals[key]
         goal = SoundRequestGoal(sound_request=req)
-        self.act_sound.send_goal_and_wait(goal, rospy.Duration(timeout))
+        status = self.act_sound.send_goal_and_wait(goal, rospy.Duration(timeout))
+        if status == GoalStatus.ABORTED:
+            rospy.logwarn(
+                "Playing %s signal was aborted. "
+                "Does its sound file exist on the machine "
+                "on which sound_play is running?"
+                % key
+            )
 
     def recognize(self, audio):
         recog_func = None


### PR DESCRIPTION
When I tried to run `speech_recognition.launch` in ROS-O in Ubuntu 24.04, I faced the following error:
```
$ roslaunch ros_speech_recognition speech_recognition.launch 
... logging to /home/choi/.ros/log/f00199e3-7c5b-11f1-b111-ac3dcbc259c5/roslaunch-choi-ThinkPad-P1-Gen-8-99357.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://choi-ThinkPad-P1-Gen-8:34111/

SUMMARY
========

PARAMETERS
 * /audio_capture/channels: 1
 * /audio_capture/depth: 16
 * /audio_capture/device: 
 * /audio_capture/format: wave
 * /audio_capture/sample_rate: 16000
 * /rosdistro: one
 * /rosversion: 1.17.3
 * /speech_recognition/audio_topic: /audio
 * /speech_recognition/auto_start: True
 * /speech_recognition/continuous: True
 * /speech_recognition/depth: 16
 * /speech_recognition/enable_sound_effect: True
 * /speech_recognition/engine: Google
 * /speech_recognition/language: en-US
 * /speech_recognition/n_channel: 1
 * /speech_recognition/sample_rate: 16000
 * /speech_recognition/self_cancellation: True
 * /speech_recognition/tts_action_names: ['sound_play']
 * /speech_recognition/tts_tolerance: 1.0
 * /speech_recognition/voice_topic: /speech_to_text

NODES
  /
    audio_capture (audio_capture/audio_capture)
    sound_play (sound_play/soundplay_node.py)
    speech_recognition (ros_speech_recognition/speech_recognition_node.py)
    speech_recognition_candidates_to_string (ros_speech_recognition/speech_recognition_candidates_to_string.py)

auto-starting new master
process[master]: started with pid [99365]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to f00199e3-7c5b-11f1-b111-ac3dcbc259c5
process[rosout-1]: started with pid [99374]
started core service [/rosout]
process[sound_play-2]: started with pid [99381]
process[audio_capture-3]: started with pid [99382]
process[speech_recognition-4]: started with pid [99388]
process[speech_recognition_candidates_to_string-5]: started with pid [99397]
/opt/ros/one/lib/sound_play/soundplay_node.py:330: PyGIDeprecationWarning: Since version 3.11, calling threads_init is no longer needed. See: https://wiki.gnome.org/PyGObject/Threading
  GObject.threads_init()
/opt/ros/one/lib/sound_play/soundplay_node.py:331: PyGIDeprecationWarning: GObject.MainLoop is deprecated; use GLib.MainLoop instead
  self.g_loop = threading.Thread(target=GObject.MainLoop().run)
[INFO] [1783686975.983063]: Enabled continuous mode
[INFO] [1783686975.984364]: Auto start: True
[ERROR] [1783686975.998503]: bad callback: <bound method ROSAudio.AudioStream.audio_cb of <__main__.ROSAudio.AudioStream object at 0x781c81b27050>>
Traceback (most recent call last):
  File "/opt/ros/one/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "<string>", line 110, in audio_cb
AttributeError: 'array.array' object has no attribute 'tostring'
```
This is because  `tostring` was removed in Python 3.9.
In Ubuntu 24.04, default Python is 3.12, so this issue occurs.
This PR fixes this issue by replacing `tostring` with `tobytes`.
Because `tobytes` exists in Python >= 2.7, this PR does not break backward compatibility.

Even after fixing this issue, another error occurred:
```
$ roslaunch ros_speech_recognition speech_recognition.launch 
... logging to /home/choi/.ros/log/3c77da3f-7c5d-11f1-a8ae-ac3dcbc259c5/roslaunch-choi-ThinkPad-P1-Gen-8-99577.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://choi-ThinkPad-P1-Gen-8:32841/

SUMMARY
========

PARAMETERS
 * /audio_capture/channels: 1
 * /audio_capture/depth: 16
 * /audio_capture/device: 
 * /audio_capture/format: wave
 * /audio_capture/sample_rate: 16000
 * /rosdistro: one
 * /rosversion: 1.17.3
 * /speech_recognition/audio_topic: /audio
 * /speech_recognition/auto_start: True
 * /speech_recognition/continuous: True
 * /speech_recognition/depth: 16
 * /speech_recognition/enable_sound_effect: True
 * /speech_recognition/engine: Google
 * /speech_recognition/language: en-US
 * /speech_recognition/n_channel: 1
 * /speech_recognition/sample_rate: 16000
 * /speech_recognition/self_cancellation: True
 * /speech_recognition/tts_action_names: ['sound_play']
 * /speech_recognition/tts_tolerance: 1.0
 * /speech_recognition/voice_topic: /speech_to_text

NODES
  /
    audio_capture (audio_capture/audio_capture)
    sound_play (sound_play/soundplay_node.py)
    speech_recognition (ros_speech_recognition/speech_recognition_node.py)
    speech_recognition_candidates_to_string (ros_speech_recognition/speech_recognition_candidates_to_string.py)

auto-starting new master
process[master]: started with pid [99585]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 3c77da3f-7c5d-11f1-a8ae-ac3dcbc259c5
process[rosout-1]: started with pid [99594]
started core service [/rosout]
process[sound_play-2]: started with pid [99601]
process[audio_capture-3]: started with pid [99602]
process[speech_recognition-4]: started with pid [99607]
process[speech_recognition_candidates_to_string-5]: started with pid [99617]
/opt/ros/one/lib/sound_play/soundplay_node.py:330: PyGIDeprecationWarning: Since version 3.11, calling threads_init is no longer needed. See: https://wiki.gnome.org/PyGObject/Threading
  GObject.threads_init()
/opt/ros/one/lib/sound_play/soundplay_node.py:331: PyGIDeprecationWarning: GObject.MainLoop is deprecated; use GLib.MainLoop instead
  self.g_loop = threading.Thread(target=GObject.MainLoop().run)
[INFO] [1783687533.754209]: Enabled continuous mode
[INFO] [1783687533.755695]: Auto start: True
[INFO] [1783687534.232682]: Set minimum energy threshold to 343.44063853053217
[ERROR] [1783687534.249374]: Error: URI is invalid: /usr/share/sounds/freedesktop/stereo/bell.ogg
[ERROR] [1783687534.251764]: Error setting up to play "/usr/share/sounds/freedesktop/stereo/bell.ogg".Does this file exist on the machineon which sound_play is running?
[ERROR] [1783687534.253778]: Exception in dispose: 'SoundType' object has no attribute 'bus'
[ERROR] [1783687534.256391]: Exception in actionlib callback: 'NoneType' object has no attribute 'command'
```
This is because the names of the sound files are changed in Ubuntu 24.04 (e.g., `/usr/share/sounds/freedesktop/stereo/bell.ogg` -> `/usr/share/sounds/freedesktop/stereo/bell.oga`).
This PR fixes this issue by reading `*.oga` only when `*.ogg` is not found.
This fix also does not break backward compatibility.